### PR TITLE
Added galaxy.libraries.get_folders().

### DIFF
--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -59,6 +59,34 @@ class LibraryClient(Client):
             payload['description'] = description
         return Client._post(self, payload, id=library_id, contents=True)
 
+    def get_folders(self, library_id, folder_id=None, name=None, deleted=False):
+        """
+        Get all the folders or filter specific one(s) via the provided ``name``
+        or ``folder_id`` in data library with id ``library_id``. Provide only one
+        argument: ``name`` or ``folder_id``, but not both.
+
+        If ``name`` is set and multiple names match the given name, all the
+        folders matching the argument will be returned.
+
+        If ``deleted`` is set to ``True``, return folders that have been deleted.
+
+        Return a list of JSON formatted dicts each containing basic information
+        about a folder.
+        """
+        library_contents = Client._get(self, id=library_id, contents=True)
+        folders = []
+        filtered_folders = []
+        for content in library_contents:
+            if content['type'] == 'folder':
+                folders.append(content)
+                if name == content['name'] or folder_id == content['id']:
+                    filtered_folders.append(content)
+                if folder_id is not None and filtered_folders:
+                    break
+        if name is not None or folder_id is not None:
+            folders = filtered_folders
+        return folders
+
     def get_libraries(self, library_id=None, name=None, deleted=False):
         """
         Get all the libraries or filter for specific one(s) via the provided name or ID.


### PR DESCRIPTION
I ran into the need of getting the list of folders in a library. I realized this was not a method already implemented. I was wondering if this is something you might want to add to bioblend.

Sorry about the newline thingy at the end of the file. Vim added it automatically. Let me know if you would prefer a pull request without it.

```
>>> gi.libraries.create_library('bioblend-dev')
{u'url': u'/api/libraries/d7155af8715f79bb', u'id': u'd7155af8715f79bb', u'name': u'bioblend-dev'}

>>> gi.libraries.create_folder('d7155af8715f79bb', 'folder_1')
[{u'url': u'/api/libraries/d7155af8715f79bb/contents/F777f57b217444f0e', u'id': u'F777f57b217444f0e', u'name': u'folder_1'}]

>>> gi.libraries.create_folder('d7155af8715f79bb', 'folder_2')
[{u'url': u'/api/libraries/d7155af8715f79bb/contents/F4230d9272de5d3a4', u'id': u'F4230d9272de5d3a4', u'name': u'folder_2'}]

>>> gi.libraries.get_folders('d7155af8715f79bb')
[{u'url': u'/api/libraries/d7155af8715f79bb/contents/F96803d911f93eda1', u'type': u'folder', u'id': u'F96803d911f93eda1', u'name': u'/'}, {u'url': u'/api/libraries/d7155af8715f79bb/contents/F777f57b217444f0e', u'type': u'folder', u'id': u'F777f57b217444f0e', u'name': u'/folder_1'}, {u'url': u'/api/libraries/d7155af8715f79bb/contents/F4230d9272de5d3a4', u'type': u'folder', u'id': u'F4230d9272de5d3a4', u'name': u'/folder_2'}]

>>> gi.libraries.get_folders('d7155af8715f79bb', name='/folder_1')
[{u'url': u'/api/libraries/d7155af8715f79bb/contents/F777f57b217444f0e', u'type': u'folder', u'id': u'F777f57b217444f0e', u'name': u'/folder_1'}]

>>> gi.libraries.get_folders('d7155af8715f79bb', folder_id='F4230d9272de5d3a4')
[{u'url': u'/api/libraries/d7155af8715f79bb/contents/F4230d9272de5d3a4', u'type': u'folder', u'id': u'F4230d9272de5d3a4', u'name': u'/folder_2'}]
```
