### PR TITLE
addition of api_download_dataset methods based on /api/histories... url

### DIFF
--- a/bioblend/galaxy/client.py
+++ b/bioblend/galaxy/client.py
@@ -145,7 +145,7 @@ class Client(object):
             try:
                 r = self.gi.make_get_request(url, params=params)
                 if r.status_code == 200 and r.content:
-                    return r.json()
+                    return r
                 else:
                     bb.log.info("GET request failed (response code: %s). %s attempts left",
                                 r.status_code, attempts_left)

--- a/bioblend/galaxy/config/__init__.py
+++ b/bioblend/galaxy/config/__init__.py
@@ -29,4 +29,4 @@ class ConfigClient(Client):
 
 
         """
-        return Client._get(self)
+        return Client._get(self).json()

--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -29,7 +29,7 @@ class DatasetClient(Client):
         params = dict(
             hda_ldda=hda_ldda,
         )
-        return Client._get(self, id=dataset_id, deleted=deleted, params=params)
+        return Client._get(self, id=dataset_id, deleted=deleted, params=params).json()
 
     def download_dataset(self, dataset_id, file_path=None, use_default_filename=True,
                          wait_for_completion=False, maxwait=12000):

--- a/bioblend/galaxy/datatypes/__init__.py
+++ b/bioblend/galaxy/datatypes/__init__.py
@@ -39,7 +39,7 @@ class DatatypesClient(Client):
         if upload_only:
             params['upload_only'] = True
 
-        return Client._get(self, params=params)
+        return Client._get(self, params=params).json()
 
     def get_sniffers(self):
         """
@@ -66,4 +66,4 @@ class DatatypesClient(Client):
         url = self.gi._make_url(self)
         url = '/'.join([url, "sniffers"])
 
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()

--- a/bioblend/galaxy/forms/__init__.py
+++ b/bioblend/galaxy/forms/__init__.py
@@ -29,7 +29,7 @@ class FormsClient(Client):
 
 
         """
-        return Client._get(self)
+        return Client._get(self).json()
 
     def show_form(self, form_id):
         """
@@ -54,7 +54,7 @@ class FormsClient(Client):
 
         """
 
-        return Client._get(self, id=form_id)
+        return Client._get(self, id=form_id).json()
 
     def create_form(self, form_xml_text):
         """

--- a/bioblend/galaxy/ftpfiles/__init__.py
+++ b/bioblend/galaxy/ftpfiles/__init__.py
@@ -20,4 +20,4 @@ class FTPFilesClient(Client):
 
 
         """
-        return Client._get(self)
+        return Client._get(self).json()

--- a/bioblend/galaxy/genomes/__init__.py
+++ b/bioblend/galaxy/genomes/__init__.py
@@ -14,7 +14,7 @@ class GenomeClient(Client):
         """
         Returns a list of installed genomes
         """
-        genomes = Client._get(self)
+        genomes = Client._get(self).json()
         return genomes
 
     def show_genome(self, id, num=None, chrom=None, low=None, high=None):
@@ -30,7 +30,7 @@ class GenomeClient(Client):
             params['low'] = low
         if high:
             params['high'] = high
-        return Client._get(self, id, params)
+        return Client._get(self, id, params).json()
 
     def install_genome(self, func='download', source=None, dbkey=None, ncbi_name=None, ensembl_dbkey=None, url_dbkey=None, indexers=None):
         """

--- a/bioblend/galaxy/groups/__init__.py
+++ b/bioblend/galaxy/groups/__init__.py
@@ -31,7 +31,7 @@ class GroupsClient(Client):
 
 
         """
-        return Client._get(self)
+        return Client._get(self).json()
 
     def show_group(self, group_id):
         """
@@ -52,7 +52,7 @@ class GroupsClient(Client):
 
         """
 
-        return Client._get(self, id=group_id)
+        return Client._get(self, id=group_id).json()
 
     def create_group(self, group_name, user_ids=[], role_ids=[]):
         """

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -41,7 +41,7 @@ class HistoryClient(Client):
         """
         if history_id is not None and name is not None:
             raise ValueError('Provide only one argument between name or history_id, but not both')
-        histories = Client._get(self, deleted=deleted)
+        histories = Client._get(self, deleted=deleted).json()
         if history_id is not None:
             history = next((_ for _ in histories if _['id'] == history_id), None)
             histories = [history] if history is not None else []
@@ -68,7 +68,7 @@ class HistoryClient(Client):
                 params['visible'] = visible
             if types is not None:
                 params['types'] = types.join(",")
-        return Client._get(self, id=history_id, contents=contents, params=params)
+        return Client._get(self, id=history_id, contents=contents, params=params).json()
 
     def delete_dataset(self, history_id, dataset_id):
         """
@@ -96,7 +96,7 @@ class HistoryClient(Client):
         url = self.gi._make_url(self, history_id, contents=True)
         # Append the dataset_id to the base history contents URL
         url = '/'.join([url, dataset_id])
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def show_dataset_collection(self, history_id, dataset_collection_id):
         """
@@ -104,7 +104,7 @@ class HistoryClient(Client):
         """
         url = self.gi._make_url(self, history_id, contents=True)
         url = '/'.join([url, "dataset_collections", dataset_collection_id])
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def show_matching_datasets(self, history_id, name_filter=None):
         """
@@ -131,7 +131,7 @@ class HistoryClient(Client):
         """
         url = self.gi._make_url(self, history_id, contents=True)
         url = '/'.join([url, dataset_id, "provenance"])
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def update_history(self, history_id, name=None, annotation=None, **kwds):
         """
@@ -337,7 +337,7 @@ class HistoryClient(Client):
         """
         url = self.gi._make_url(self, None)
         url = '/'.join([url, 'most_recently_used'])
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def export_history(self, history_id, gzip=True, include_hidden=False,
                        include_deleted=False, wait=False):

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -44,7 +44,7 @@ class JobsClient(Client):
                  u'tool_id': u'upload1',
                  u'update_time': u'2014-03-01T16:05:39.558458'}]
         """
-        return Client._get(self)
+        return Client._get(self).json()
 
     def show_job(self, job_id):
         """
@@ -75,7 +75,7 @@ class JobsClient(Client):
 
         """
 
-        return Client._get(self, id=job_id)
+        return Client._get(self, id=job_id).json()
 
     def search_jobs(self, job_info):
         """

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -41,7 +41,7 @@ class LibraryClient(Client):
     def __show_item(self, library_id, item_id):
         url = self.gi._make_url(self, library_id, contents=True)
         url = '/'.join([url, item_id])
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def delete_library_dataset(self, library_id, dataset_id, purged=False):
         """
@@ -122,7 +122,7 @@ class LibraryClient(Client):
         """
         if folder_id is not None and name is not None:
             raise ValueError('Provide only one argument between name or folder_id, but not both')
-        library_contents = Client._get(self, id=library_id, contents=True)
+        library_contents = Client._get(self, id=library_id, contents=True).json()
         if folder_id is not None:
             folder = next((_ for _ in library_contents if _['type'] == 'folder' and _['id'] == folder_id), None)
             folders = [folder] if folder is not None else []
@@ -145,7 +145,7 @@ class LibraryClient(Client):
         """
         if library_id is not None and name is not None:
             raise ValueError('Provide only one argument between name or library_id, but not both')
-        libraries = Client._get(self, deleted=deleted)
+        libraries = Client._get(self, deleted=deleted).json()
         if library_id is not None:
             library = next((_ for _ in libraries if _['id'] == library_id), None)
             libraries = [library] if library is not None else []
@@ -162,7 +162,7 @@ class LibraryClient(Client):
 
         Return a list of JSON formatted dicts containing library details.
         """
-        return Client._get(self, id=library_id, contents=contents)
+        return Client._get(self, id=library_id, contents=contents).json()
 
     def _do_upload(self, **keywords):
         """

--- a/bioblend/galaxy/quotas/__init__.py
+++ b/bioblend/galaxy/quotas/__init__.py
@@ -33,7 +33,7 @@ class QuotaClient(Client):
 
 
         """
-        return Client._get(self, deleted=deleted)
+        return Client._get(self, deleted=deleted).json()
 
     def show_quota(self, quota_id, deleted=False):
         """
@@ -63,4 +63,4 @@ class QuotaClient(Client):
 
 
         """
-        return Client._get(self, id=quota_id, deleted=deleted)
+        return Client._get(self, id=quota_id, deleted=deleted).json()

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -59,7 +59,7 @@ class ToolClient(Client):
         params = {}
         params['in_panel'] = in_panel
         params['trackster'] = trackster
-        return Client._get(self, params=params)
+        return Client._get(self, params=params).json()
 
     def show_tool(self, tool_id, io_details=False, link_details=False):
         """
@@ -77,7 +77,7 @@ class ToolClient(Client):
         params = {}
         params['io_details'] = io_details
         params['link_details'] = link_details
-        return Client._get(self, id=tool_id, params=params)
+        return Client._get(self, id=tool_id, params=params).json()
 
     def run_tool(self, history_id, tool_id, tool_inputs):
         """

--- a/bioblend/galaxy/toolshed/__init__.py
+++ b/bioblend/galaxy/toolshed/__init__.py
@@ -31,7 +31,7 @@ class ToolShedClient(Client):
             Changed method name from ``get_tools`` to ``get_repositories`` to
             better align with the Tool Shed concepts
         """
-        return Client._get(self)
+        return Client._get(self).json()
 
     def show_repository(self, toolShed_id):
         """
@@ -54,7 +54,7 @@ class ToolShedClient(Client):
             Changed method name from ``show_tool`` to ``show_repository`` to
             better align with the Tool Shed concepts
         """
-        return Client._get(self, id=toolShed_id)
+        return Client._get(self, id=toolShed_id).json()
 
     def install_repository_revision(self, tool_shed_url, name, owner,
                                     changeset_revision,

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -26,14 +26,14 @@ class UserClient(Client):
                      u'url': u'/api/users/dda47097d9189f15'}]
 
         """
-        return Client._get(self, deleted=deleted)
+        return Client._get(self, deleted=deleted).json()
 
     def show_user(self, user_id, deleted=False):
         """
         Display information about a user. If ``deleted`` is set to ``True``,
         display information about a deleted user.
         """
-        return Client._get(self, id=user_id, deleted=deleted)
+        return Client._get(self, id=user_id, deleted=deleted).json()
 
     def create_user(self, user_email):
         """
@@ -81,7 +81,7 @@ class UserClient(Client):
         """
         url = self.gi._make_url(self, None)
         url = '/'.join([url, 'current'])
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def create_user_apikey(self, user_id):
         """

--- a/bioblend/galaxy/visual/__init__.py
+++ b/bioblend/galaxy/visual/__init__.py
@@ -31,7 +31,7 @@ class VisualClient(Client):
 
 
         """
-        results = Client._get(self)
+        results = Client._get(self).json()
         return results
 
     def show_visualization(self, visual_id):
@@ -58,4 +58,4 @@ class VisualClient(Client):
                    u'user_id': u'21e4aed91386ca8b'}
 
         """
-        return Client._get(self, id=visual_id)
+        return Client._get(self, id=visual_id).json()

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -40,7 +40,7 @@ class WorkflowClient(Client):
         kwargs = {'deleted': deleted}
         if published:
             kwargs['params'] = {'show_published': 'True'}
-        workflows = Client._get(self, **kwargs)
+        workflows = Client._get(self, **kwargs).json()
         if workflow_id is not None:
             workflow = next((_ for _ in workflows if _['id'] == workflow_id), None)
             workflows = [workflow] if workflow is not None else []
@@ -65,14 +65,14 @@ class WorkflowClient(Client):
                    u'url': u'/api/workflows/92c56938c2f9b315'}
 
         """
-        return Client._get(self, id=workflow_id)
+        return Client._get(self, id=workflow_id).json()
 
     def get_workflow_inputs(self, workflow_id, label):
         """
         Get a list of workflow input IDs that match the given label.
         If no input matches the given label, an empty list is returned.
         """
-        wf = Client._get(self, id=workflow_id)
+        wf = Client._get(self, id=workflow_id).json()
         inputs = wf['inputs']
         return [id for id in inputs if inputs[id]['label'] == label]
 
@@ -133,7 +133,7 @@ class WorkflowClient(Client):
         url = self.gi._make_url(self)
         url = '/'.join([url, "download"])
         url = '/'.join([url, workflow_id])
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def export_workflow_to_local_path(self, workflow_id, file_local_path, use_default_filename=True):
         """

--- a/bioblend/toolshed/repositories/__init__.py
+++ b/bioblend/toolshed/repositories/__init__.py
@@ -31,7 +31,7 @@ class ToolShedClient(Client):
             Changed method name from ``get_tools`` to ``get_repositories`` to
             better align with the Tool Shed concepts
         """
-        return Client._get(self)
+        return Client._get(self).json()
 
     def show_repository(self, toolShed_id):
         """
@@ -55,7 +55,7 @@ class ToolShedClient(Client):
             Changed method name from ``show_tool`` to ``show_repository`` to
             better align with the Tool Shed concepts
         """
-        return Client._get(self, id=toolShed_id)
+        return Client._get(self, id=toolShed_id).json()
 
     def get_ordered_installable_revisions(self, name, owner):
         """
@@ -76,7 +76,7 @@ class ToolShedClient(Client):
         params = {}
         params['name'] = name
         params['owner'] = owner
-        r = Client._get(self, url=url, params=params)
+        r = Client._get(self, url=url, params=params).json()
 
         return r
 
@@ -116,7 +116,7 @@ class ToolShedClient(Client):
         params['owner'] = owner
         params['changeset_revision'] = changeset_revision
 
-        return Client._get(self, url=url, params=params)
+        return Client._get(self, url=url, params=params).json()
 
     def repository_revisions(self, downloadable=None, malicious=None,
             tools_functionally_correct=None, missing_test_components=None,
@@ -184,7 +184,7 @@ class ToolShedClient(Client):
         if skip_tool_test:
             params['skip_tool_test'] = 'True'
 
-        return Client._get(self, url=url, params=params)
+        return Client._get(self, url=url, params=params).json()
 
     def show_repository_revision(self, metadata_id):
         '''
@@ -219,7 +219,7 @@ class ToolShedClient(Client):
         # since metadata_id has to be defined, easy to create the url here
         url = self.gi.url + '/repository_revisions/' + metadata_id
 
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def get_categories(self):
         """
@@ -241,7 +241,7 @@ class ToolShedClient(Client):
         .. versionadded:: 0.5.2
         """
         url = urlparse.urljoin(self.url, 'categories')
-        return Client._get(self, url=url)
+        return Client._get(self, url=url).json()
 
     def update_repository(self, id, tar_ball_path, commit_message=None):
         url = self.gi._make_url(self, id) + '/changeset_revision'


### PR DESCRIPTION
We propose this pull request to use the /api/histories/history_id/contents/dataset_id/display url rather than the /datasets/dataset_id/display url to download a file.
It enable a galaxy data download when the option require_login is True (no redirection towards http://galaxy/root)
We propose also to modify the methods _get and _get_retry of the Client class to allow the return of the request object and not only the request.json. Request object is used to write the content in the output file. Thus we take advantage of the bioblend request management including https urls. The actual download_dataset methods does not support the https.
