### PR TITLE
refactor galaxy client _get

### DIFF
--- a/bioblend/galaxy/client.py
+++ b/bioblend/galaxy/client.py
@@ -131,10 +131,11 @@ class Client(object):
                 else:
                     msg = "GET: error %s: %r" % (r.status_code, r.content)
             msg = "%s, %d attempts left" % (msg, attempts_left)
-            bb.log.info(msg)
             if attempts_left <= 0:
+                bb.log.error(msg)
                 raise ConnectionError(msg)
             else:
+                bb.log.warn(msg)
                 time.sleep(retry_delay)
 
     def _post(self, payload, id=None, deleted=False, contents=None, url=None, files_attached=False):


### PR DESCRIPTION
This PR deals with a problem introduced in https://github.com/afgane/bioblend/pull/100. The method has been changed to return the request object instead of its (decoded) JSON content, but the check-errors-and-retry logic still deals with JSON problems (the part that catches `ValueError`, which cannot be triggered anymore).

As much as I hate to keep adding arguments to a method that already has plenty, I added a `json` arg that defaults to `True` (thus eliminating -- again :) -- the need for two separate methods) and reworked the logic so that it deals with JSON problems only when decoding is actually requested and is (hopefully) a bit more readable. The alternative would have been to move JSON-specific retry logic to the non-raw version of `_get`, making the code both redundant and more complex (the two methods would have needed to share the retry counter).
