### PR TITLE
Rename input_ids and output_ids Workflow attributes to source_ids and sink_ids respectively

### DIFF
--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -208,9 +208,9 @@ class Workflow(Wrapper):
         heads, tails = set(dag), set(inv_dag)
         object.__setattr__(self, 'dag', dag)
         object.__setattr__(self, 'inv_dag', inv_dag)
-        object.__setattr__(self, 'input_ids', heads - tails)
-        assert self.input_ids == set(self.inputs)
-        object.__setattr__(self, 'output_ids', tails - heads)
+        object.__setattr__(self, 'source_ids', heads - tails)
+        assert self.data_input_ids == set(self.inputs)
+        object.__setattr__(self, 'sink_ids', tails - heads)
         object.__setattr__(self, 'missing_ids', missing_ids)
 
     @property
@@ -247,16 +247,16 @@ class Workflow(Wrapper):
         Return a topological sort of the workflow's DAG.
         """
         ids = []
-        input_ids = self.input_ids.copy()
+        source_ids = self.source_ids.copy()
         inv_dag = dict((k, v.copy()) for k, v in self.inv_dag.iteritems())
-        while input_ids:
-            head = input_ids.pop()
+        while source_ids:
+            head = source_ids.pop()
             ids.append(head)
             for tail in self.dag.get(head, []):
                 incoming = inv_dag[tail]
                 incoming.remove(head)
                 if not incoming:
-                    input_ids.add(tail)
+                    source_ids.add(tail)
         return ids
 
     @staticmethod

--- a/tests/TestGalaxyObjects.py
+++ b/tests/TestGalaxyObjects.py
@@ -159,8 +159,9 @@ class TestWorkflow(unittest.TestCase):
         self.assertEqual(
             self.wf.tool_labels_to_ids, {'Paste1': set(['573'])}
             )
-        self.assertEqual(self.wf.input_ids, set(['571', '572']))
-        self.assertEqual(self.wf.output_ids, set(['573']))
+        self.assertEqual(self.wf.data_input_ids, set(['571', '572']))
+        self.assertEqual(self.wf.source_ids, set(['571', '572']))
+        self.assertEqual(self.wf.sink_ids, set(['573']))
 
     def test_dag(self):
         inv_dag = {}


### PR DESCRIPTION
As explained in issue #108 , ```input_ids``` Workflow attribute is not properly defined: it seems to be the same of ```data_input_ids``` attribute (i.e. ids of the workflow data inputs), while it is the set of ids of the source vertices of the workflow DAG, which can be either tools or data_inputs. Similarly for ```output_ids```.

I propose to rename both ```input_ids``` and ```output_ids``` to ```source_ids``` and ```sink_ids``` respectively to avoid confusion, even if this will remove these attributes from the Workflow objects.