### PR TITLE
Restore initial 'F' in library folder IDs. Fix #111.

### DIFF
--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -644,8 +644,6 @@ class LibraryContentInfo(ContentInfo):
     """
     def __init__(self, info_dict, gi=None):
         super(LibraryContentInfo, self).__init__(info_dict, gi=gi)
-        if self.id.startswith('F'):
-            object.__setattr__(self, 'id', self.id[1:])
 
     @property
     def gi_module(self):
@@ -1078,8 +1076,6 @@ class Folder(Wrapper):
 
     def __init__(self, f_dict, container_id, gi=None):
         super(Folder, self).__init__(f_dict, gi=gi)
-        if self.id.startswith('F'):  # folder id from library contents
-            object.__setattr__(self, 'id', self.id[1:])
         object.__setattr__(self, 'container_id', container_id)
 
     @property

--- a/tests/TestGalaxyObjects.py
+++ b/tests/TestGalaxyObjects.py
@@ -409,8 +409,9 @@ class TestLibrary(GalaxyObjectsTestBase):
         self.assertEqual(folder.container_id, self.lib.id)
         self.assertEqual(len(self.lib.content_infos), 2)
         self.assertEqual(len(self.lib.folder_ids), 2)
-        self.assertEqual(len(self.lib.dataset_ids), 0)
         self.assertTrue(folder.id in self.lib.folder_ids)
+        retrieved = self.lib.get_folder(folder.id)
+        self.assertEqual(folder.id, retrieved.id)
 
     def __check_datasets(self, dss):
         self.assertEqual(len(dss), len(self.lib.dataset_ids))


### PR DESCRIPTION
I don't know exactly why the removing of the initial 'F' was done in the first place, so opening a PR.