### PR TITLE
non-root Folder automatically gets parent attribute

### DIFF
--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -1107,8 +1107,7 @@ class Folder(Wrapper):
                 # older Galaxy versions strip the F
                 parent_id = u'F%s' % (parent_id)
             try:
-                parent = self.container.get_folder(parent_id)
-                return parent
+                return self.container.get_folder(parent_id)
             except bioblend.galaxy.client.ConnectionError:
                 # Depending on version, galaxy is returning a dummy parent_id 
                 #  for the root Folder
@@ -1116,8 +1115,7 @@ class Folder(Wrapper):
                 self.wrapped['dummy_parent_id']=self.wrapped['parent_id']
                 self.wrapped['parent_id']=None
 
-        # folder is root, return library
-        return self.container
+        return None
 
     @property
     def gi_module(self):

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -1102,8 +1102,7 @@ class Folder(Wrapper):
         Return folder indicated by 'parent_id'
         """
         parent_id = self.wrapped.get('parent_id',None)
-        # 'F21000...' seems to be a dummy ID (encoding of 0 or None?)
-        if parent_id is not None and parent_id != 'F2100007bb1a6035d':
+        if parent_id is not None:
             if parent_id[0]!='F':
                 # older Galaxy versions strip the F
                 parent_id = u'F%s' % (parent_id)
@@ -1111,10 +1110,10 @@ class Folder(Wrapper):
                 parent = self.container.get_folder(parent_id)
                 return parent
             except bioblend.galaxy.client.ConnectionError:
-                # Sometimes galaxy is returning a dummy parent_id 
-                # If it's not caught above, we deal with it here
-                # Clear the parent_id, so we don't spew errors
-                self.wrapped['broken_parent_id']=self.wrapped['parent_id']
+                # Depending on version, galaxy is returning a dummy parent_id 
+                #  for the root Folder
+                # Clear the parent_id, so we don't try to load it each time
+                self.wrapped['dummy_parent_id']=self.wrapped['parent_id']
                 self.wrapped['parent_id']=None
 
         # folder is root, return library

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -94,7 +94,7 @@ class Wrapper(object):
         The GalaxyInstance module that deals with objects of this type.
         """
         pass
-    
+
     @property
     def parent(self):
         """
@@ -626,7 +626,9 @@ class LibraryDataset(LibRelatedDataset):
     SRC = 'ld'
 
     def delete(self, purged=False):
-        self.gi.gi.libraries.delete_library_dataset(self.container.id, self.id, purged=purged)
+        self.gi.gi.libraries.delete_library_dataset(
+                self.container.id, self.id, purged=purged
+                )
         self.container.refresh()
         self.refresh()
 
@@ -1092,8 +1094,8 @@ class Folder(Wrapper):
         The root folder will have the library as a parent.
         """
         if self._cached_parent is None:
-            object.__setattr__(self, 
-                               '_cached_parent', 
+            object.__setattr__(self,
+                               '_cached_parent',
                                self._get_parent())
         return self._cached_parent
 
@@ -1101,19 +1103,19 @@ class Folder(Wrapper):
         """
         Return folder indicated by 'parent_id'
         """
-        parent_id = self.wrapped.get('parent_id',None)
+        parent_id = self.wrapped.get('parent_id', None)
         if parent_id is not None:
-            if parent_id[0]!='F':
+            if parent_id[0] != 'F':
                 # older Galaxy versions strip the F
                 parent_id = u'F%s' % (parent_id)
             try:
                 return self.container.get_folder(parent_id)
             except bioblend.galaxy.client.ConnectionError:
-                # Depending on version, galaxy is returning a dummy parent_id 
+                # Depending on version, galaxy is returning a dummy parent_id
                 #  for the root Folder
                 # Clear the parent_id, so we don't try to load it each time
-                self.wrapped['dummy_parent_id']=self.wrapped['parent_id']
-                self.wrapped['parent_id']=None
+                self.wrapped['dummy_parent_id'] = self.wrapped['parent_id']
+                self.wrapped['parent_id'] = None
 
         return None
 

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -1077,6 +1077,28 @@ class Folder(Wrapper):
     def __init__(self, f_dict, container, gi=None):
         super(Folder, self).__init__(f_dict, gi=gi)
         object.__setattr__(self, 'container', container)
+        self._set_parent_folder()
+
+    def _set_parent_folder(self):
+        """
+        Set the parent attribute to the folder indicated by 'parent_id'
+
+        Root folder will have no parent.
+        """
+        parent = None
+        parent_id = self.wrapped.get('parent_id',None)
+        if parent_id is not None:
+            if parent_id[0]!='F':
+                # older Galaxy versions strip the F
+                parent_id = u'F%s' % (parent_id)
+
+            try:
+                parent = self.container.get_folder(parent_id)
+            except bioblend.galaxy.client.ConnectionError:
+                # the get method will log this kind of error
+                #  but it's not critical
+                pass
+        object.__setattr__(self, 'parent', parent)
 
     @property
     def gi_module(self):


### PR DESCRIPTION
As per discussion in #114, simply uses the 'parent_id' value in the wrapped Folder data to fetch the indicated parent Folder and set as the current Folder's 'parent' attribute.