### PR TITLE
Fix for #84 and documentation improvements

### DIFF
--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -23,7 +23,13 @@ class DatasetClient(Client):
         Display information about and/or content of a dataset. This can be a
         history or a library dataset.
 
-        :type hda_ldda: string
+        :type dataset_id: str
+        :param dataset_id: Encoded Dataset ID
+
+        :type deleted: bool
+        :param deleted: Whether to return results for a deleted dataset
+
+        :type hda_ldda: str
         :param hda_ldda: Whether to show a history dataset ('hda' - the default) or library
                          dataset ('ldda').
         """
@@ -37,18 +43,18 @@ class DatasetClient(Client):
         """
         Downloads the dataset identified by 'id'.
 
-        :type dataset_id: string
+        :type dataset_id: str
         :param dataset_id: Encoded Dataset ID
 
-        :type file_path: string
+        :type file_path: str
         :param file_path: If the file_path argument is provided, the dataset will be streamed to disk
                           at that path (Should not contain filename if use_default_name=True).
                           If the file_path argument is not provided, the dataset content is loaded into memory
                           and returned by the method (Memory consumption may be heavy as the entire file
                           will be in memory).
 
-        :type use_default_name: boolean
-        :param use_default_name: If the use_default_name parameter is True, the exported
+        :type use_default_filename: boolean
+        :param use_default_filename: If the use_default_name parameter is True, the exported
                                  file will be saved as file_path/%s,
                                  where %s is the dataset name.
                                  If use_default_name is False, file_path is assumed to
@@ -137,6 +143,9 @@ class DatasetClient(Client):
     def show_stderr(self, dataset_id):
         """
         Display stderr output of a dataset.
+
+        :type dataset_id: str
+        :param dataset_id: Encoded Dataset ID
         """
         res = urllib2.urlopen(self.url[:-len("/api/datasets/")+1]+"/datasets/"+dataset_id+"/stderr")
         return res.read()
@@ -144,6 +153,9 @@ class DatasetClient(Client):
     def show_stdout(self, dataset_id):
         """
         Display stdout output of a dataset.
+
+        :type dataset_id: str
+        :param dataset_id: Encoded Dataset ID
         """
         res = urllib2.urlopen(self.url[:-len("/api/datasets/")+1]+"/datasets/"+dataset_id+"/stdout")
         return res.read()

--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -53,14 +53,14 @@ class DatasetClient(Client):
                           and returned by the method (Memory consumption may be heavy as the entire file
                           will be in memory).
 
-        :type use_default_filename: boolean
+        :type use_default_filename: bool
         :param use_default_filename: If the use_default_name parameter is True, the exported
                                  file will be saved as file_path/%s,
                                  where %s is the dataset name.
                                  If use_default_name is False, file_path is assumed to
                                  contain the full file path including filename.
 
-        :type wait_for_completion: boolean
+        :type wait_for_completion: bool
         :param wait_for_completion: If wait_for_completion is True, this call will block until the dataset is ready.
                                     If the dataset state becomes invalid, a DatasetStateException will be thrown.
 

--- a/bioblend/galaxy/folders/__init__.py
+++ b/bioblend/galaxy/folders/__init__.py
@@ -15,8 +15,8 @@ class FoldersClient(Client):
         """
         Display information about a folder.
 
-        :type folder_id: an encoded id string (has to be prefixed by 'F')
-        :param folder_id: the folder's encoded id (required)
+        :type folder_id: str
+        :param folder_id: the folder's encoded id, prefixed by 'F'
 
         :rtype: dict
         :return: dictionary including details of the folder
@@ -29,8 +29,8 @@ class FoldersClient(Client):
         Marks the folder with the given ``id`` as `deleted` (or removes the
         `deleted` mark if the `undelete` param is True).
 
-        :type folder_id: an encoded id string (has to be prefixed by 'F')
-        :param folder_id: the folder's encoded id (required)
+        :type folder_id: str
+        :param folder_id: the folder's encoded id, prefixed by 'F'
 
         :type undelete: bool
         :param undelete: If set to True, the folder will be undeleted

--- a/bioblend/galaxy/forms/__init__.py
+++ b/bioblend/galaxy/forms/__init__.py
@@ -35,7 +35,7 @@ class FormsClient(Client):
         """
         Display information on a single form
 
-        :type form_id: string
+        :type form_id: str
         :param form_id: Encoded form ID
 
         :rtype: dict
@@ -60,10 +60,10 @@ class FormsClient(Client):
         """
         Create a new form
 
-        :type   form_xml_text: string
+        :type   form_xml_text: str
         :param  form_xml_text: Form xml to create a form on galaxy instance
 
-        :rtype:     string
+        :rtype:     str
         :returns:   Unique url of newly created form with encoded id
 
         """

--- a/bioblend/galaxy/genomes/__init__.py
+++ b/bioblend/galaxy/genomes/__init__.py
@@ -20,6 +20,21 @@ class GenomeClient(Client):
     def show_genome(self, id, num=None, chrom=None, low=None, high=None):
         """
         Returns information about build <id>
+
+        :type id: str
+        :param id: Genome build ID to use
+
+        :type num: str
+        :param num: num
+
+        :type chrom: str
+        :param chrom: chrom
+
+        :type low: str
+        :param low: low
+
+        :type high: str
+        :param high: high
         """
         params = {}
         if num:
@@ -32,29 +47,38 @@ class GenomeClient(Client):
             params['high'] = high
         return Client._get(self, id, params)
 
-    def install_genome(self, func='download', source=None, dbkey=None, ncbi_name=None, ensembl_dbkey=None, url_dbkey=None, indexers=None):
+    def install_genome(self, func='download', source=None, dbkey=None,
+                       ncbi_name=None, ensembl_dbkey=None, url_dbkey=None,
+                       indexers=None):
         """
         Download and/or index a genome.
 
-        Parameters::
 
-            dbkey           DB key of the build to download, ignored unless 'UCSC' is specified as the source
-            ncbi_name       NCBI's genome identifier, ignored unless NCBI is specified as the source
-            ensembl_dbkey   Ensembl's genome identifier, ignored unless Ensembl is specified as the source
-            url_dbkey       DB key to use for this build, ignored unless URL is specified as the source
-            source          Data source for this build. Can be: UCSC, Ensembl, NCBI, URL
-            indexers        POST array of indexers to run after downloading (indexers[] = first, indexers[] = second, ...)
-            func            Allowed values:
-                            'download'  Download and index
-                            'index'     Index only
+        :type dbkey: str
+        :param dbkey: DB key of the build to download, ignored unless 'UCSC' is specified as the source
 
-        Returns::
+        :type ncbi_name: str
+        :param ncbi_name: NCBI's genome identifier, ignored unless NCBI is specified as the source
 
-            If no error:
-            dict( status: 'ok', job: <job ID> )
+        :type ensembl_dbkey: str
+        :param ensembl_dbkey: Ensembl's genome identifier, ignored unless Ensembl is specified as the source
 
-            If error:
-            dict( status: 'error', error: <error message> )
+        :type url_dbkey: str
+        :param url_dbkey: DB key to use for this build, ignored unless URL is specified as the source
+
+        :type source: str
+        :param source: Data source for this build. Can be: UCSC, Ensembl, NCBI, URL
+
+        :type indexers: list
+        :param indexers: POST array of indexers to run after downloading (indexers[] = first, indexers[] = second, ...)
+
+        :type func: str
+        :param func: Allowed values: 'download', Download and index; 'index', Index only
+
+        :rtype: dict
+        :return: dict( status: 'ok', job: <job ID> )
+                 If error:
+                 dict( status: 'error', error: <error message> )
         """
         payload = {}
         if source:

--- a/bioblend/galaxy/groups/__init__.py
+++ b/bioblend/galaxy/groups/__init__.py
@@ -37,7 +37,7 @@ class GroupsClient(Client):
         """
         Display information on a single group
 
-        :type group_id: string
+        :type group_id: str
         :param group_id: Encoded group ID
 
 
@@ -58,8 +58,14 @@ class GroupsClient(Client):
         """
         Create a new Galaxy group
 
-        :param group_name: string
-        :type group_name: A name for new group
+        :type group_name: str
+        :param group_name: A name for new group
+
+        :type user_ids: list
+        :param user_ids: A list of encoded user IDs to add to the new group
+
+        :type role_ids: list
+        :param role_ids: A list of encoded role IDs to add to the new group
 
         :rtype: list
         :return: A (size 1) list with newly created group

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -18,6 +18,12 @@ class HistoryClient(Client):
     def create_history(self, name=None):
         """
         Create a new history, optionally setting the ``name``.
+
+        :type name: str
+        :param name: Optional name for new history
+
+        :rtype: dict
+        :return: Dictionary containing information about newly created history
         """
         payload = {}
         if name is not None:
@@ -32,9 +38,16 @@ class HistoryClient(Client):
 
         If ``deleted`` is set to ``True``, return histories that have been deleted.
 
-        Return a list of history element dicts. If more than one history
-        matches the given ``name``, return the list of all the histories with the
-        given name.
+        :type history_id: str
+        :param history_id: Encoded history ID to filter on
+
+        :type name: str
+        :param name: Name of history to filter on
+
+        :rtype: dict
+        :return: Return a list of history element dicts. If more than one
+                 history matches the given ``name``, return the list of all the
+                 histories with the given name.
         """
         if history_id is not None and name is not None:
             raise ValueError('Provide only one argument between name or history_id, but not both')
@@ -49,11 +62,25 @@ class HistoryClient(Client):
     def show_history(self, history_id, contents=False, deleted=None, visible=None, details=None, types=None):
         """
         Get details of a given history. By default, just get the history meta
-        information. If ``contents`` is set to ``True``, get the complete list of
-        datasets in the given history. ``deleted``, ``visible``, and ``details`` are
-        used only if ``contents`` is ``True`` and are used to modify the datasets returned
-        and their contents. Set ``details`` to 'all' to get more information
-        about each dataset.
+        information.
+
+        :type history_id: str
+        :param history_id: Encoded history ID to filter on
+
+        :type contents: str
+        :param contents: When true, the complete list of datasets in the given history.
+
+        :type deleted: str
+        :param deleted: Used when contents=True, includes deleted datasets is history dataset list
+
+        :type visible: str
+        :param visible: Used when contents=True, includes only visible datasets is history dataset list
+
+        :type details: str
+        :param details: Used when contents=True, includes dataset details. Set to 'all' for the most information
+
+        :type types: str
+        :param types: ???
         """
         params = {}
         if contents:
@@ -70,6 +97,12 @@ class HistoryClient(Client):
     def delete_dataset(self, history_id, dataset_id):
         """
         Mark corresponding dataset as deleted.
+
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type dataset_id: str
+        :param dataset_id: Encoded dataset ID
         """
         url = self.gi._make_url(self, history_id, contents=True)
         # Append the dataset_id to the base history contents URL
@@ -79,6 +112,12 @@ class HistoryClient(Client):
     def delete_dataset_collection(self, history_id, dataset_collection_id):
         """
         Mark corresponding dataset collection as deleted.
+
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type dataset_collection_id: str
+        :param dataset_collection_id: Encoded dataset collection ID
         """
         url = self.gi._make_url(self, history_id, contents=True)
         # Append the dataset_id to the base history contents URL
@@ -87,8 +126,13 @@ class HistoryClient(Client):
 
     def show_dataset(self, history_id, dataset_id):
         """
-        Get details about a given history dataset. The required ``history_id``
-        can be obtained from the datasets's history content details.
+        Get details about a given history dataset.
+
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type dataset_id: str
+        :param dataset_id: Encoded dataset ID
         """
         url = self.gi._make_url(self, history_id, contents=True)
         # Append the dataset_id to the base history contents URL
@@ -98,6 +142,12 @@ class HistoryClient(Client):
     def show_dataset_collection(self, history_id, dataset_collection_id):
         """
         Get details about a given history dataset collection.
+
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type dataset_collection_id: str
+        :param dataset_collection_id: Encoded dataset collection ID
         """
         url = self.gi._make_url(self, history_id, contents=True)
         url = '/'.join([url, "dataset_collections", dataset_collection_id])
@@ -107,9 +157,14 @@ class HistoryClient(Client):
         """
         Get dataset details for matching datasets within a history.
 
-        Only datasets whose name matches the ``name_filter`` regular
-        expression will be returned; use plain strings for exact
-        matches and None to match all datasets in the history.
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type name_filter: str
+        :param name_filter: Only datasets whose name matches the
+                            ``name_filter`` regular expression will be
+                            returned; use plain strings for exact matches and
+                            None to match all datasets in the history.
         """
         if isinstance(name_filter, basestring):
             name_filter = re.compile(name_filter + '$')
@@ -123,8 +178,16 @@ class HistoryClient(Client):
         ``tool_id``, ``stdout``, ``stderr``, ``parameters``, ``inputs``,
         etc...).
 
-        If ``follow`` is ``True``, recursively fetch dataset provenance
-        information for all inputs and their inputs, etc....
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type dataset_id: str
+        :param dataset_id: Encoded dataset ID
+
+        :type follow: bool
+        :param follow: If ``follow`` is ``True``, recursively fetch dataset
+                       provenance information for all inputs and their inputs,
+                       etc....
         """
         url = self.gi._make_url(self, history_id, contents=True)
         url = '/'.join([url, dataset_id, "provenance"])
@@ -137,20 +200,27 @@ class HistoryClient(Client):
 
         :type history_id: str
         :param history_id: Encoded history ID
+
         :type name: str
         :param name: Replace history name with the given string
+
         :type annotation: str
         :param annotation: Replace history annotation with given string
+
         :type deleted: bool
         :param deleted: Mark or unmark history as deleted
+
         :type published: bool
         :param published: Mark or unmark history as published
+
         :type importable: bool
         :param importable: Mark or unmark history as importable
+
         :type tags: list
         :param tags: Replace history tags with the given list
 
-        :rtype: status_code (int)
+        :rtype: int
+        :return: status code
 
         """
         kwds['name'] = name
@@ -164,16 +234,12 @@ class HistoryClient(Client):
 
         :type history_id: str
         :param history_id: Encoded history ID
-        :type name: str
-        :param name: Replace history dataset name with the given string
-        :type annotation: str
-        :param annotation: Replace history dataset annotation with given string
-        :type deleted: bool
-        :param deleted: Mark or unmark history dataset as deleted
-        :type visible: bool
-        :param visible: Mark or unmark history dataset as visible
 
-        :rtype: status_code (int)
+        :type dataset_id: str
+        :param dataset_id: Id of the dataset
+
+        :rtype: int
+        :return: status code
         """
         url = self.gi._make_url(self, history_id, contents=True)
         # Append the dataset_id to the base history contents URL
@@ -187,14 +253,12 @@ class HistoryClient(Client):
 
         :type history_id: str
         :param history_id: Encoded history ID
-        :type name: str
-        :param name: Replace history dataset collection name with the given string
-        :type deleted: bool
-        :param deleted: Mark or unmark history dataset collection as deleted.
-        :type visible: bool
-        :param visible: Mark or unmark history dataset collection as visible.
 
-        :rtype: status_code (int)
+        :type dataset_collection_id: str
+        :param dataset_collection_id: Encoded dataset_collection ID
+
+        :rtype: int
+        :return: status code
         """
         url = self.gi._make_url(self, history_id, contents=True)
         url = '/'.join([url, "dataset_collections", dataset_collection_id])
@@ -206,11 +270,12 @@ class HistoryClient(Client):
 
         :type history_id: str
         :param history_id: Encoded history ID
+
         :type tag: str
         :param tag: Add tag to history
 
-        :rtype: json object
-        :return: Return json object
+        :rtype: dict
+        :return: A dictionary with information regarding the tag.
                  For example::
 
                  {'model_class':'HistoryTagAssociation', 'user_tname': 'NGS_PE_RUN', 'id': 'f792763bee8d277a', 'user_value': None}
@@ -231,6 +296,12 @@ class HistoryClient(Client):
         Upload a dataset into the history from a library. Requires the
         library dataset ID, which can be obtained from the library
         contents.
+
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type lib_dataset_id: str
+        :param lib_dataset_id: Encoded library dataset ID
         """
         payload = {
             'content': lib_dataset_id,
@@ -240,6 +311,15 @@ class HistoryClient(Client):
         return Client._post(self, payload, id=history_id, contents=True)
 
     def create_dataset_collection(self, history_id, collection_description):
+        """
+        Create a new dataset collection
+
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type collection_description: str
+        :param collection_description: a description of the dataset collection
+        """
         try:
             collection_description = collection_description.to_dict()
         except AttributeError:
@@ -257,6 +337,10 @@ class HistoryClient(Client):
         """
         Download a ``dataset_id`` from history with ``history_id`` to a
         file on the local file system, saving it to ``file_path``.
+
+        Legacy use only, refer to
+        ``bioblend.galaxy.dataset.DatasetClient.download_dataset()`` for
+        available parameters
         """
         dc = DatasetClient(self.gi)
         return dc.download_dataset(dataset_id, file_path=file_path,
@@ -267,7 +351,11 @@ class HistoryClient(Client):
         """
         Delete a history.
 
-        If ``purge`` is set to ``True``, also purge the history.
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :type purge: bool
+        :param purge: Purge the history
 
         .. note::
           For the purge option to work, the Galaxy instance must have the
@@ -282,6 +370,9 @@ class HistoryClient(Client):
     def undelete_history(self, history_id):
         """
         Undelete a history
+
+        :type history_id: str
+        :param history_id: Encoded history ID
         """
         url = self.gi._make_url(self, history_id, deleted=True)
         # Append the 'undelete' action to the history URL
@@ -290,10 +381,16 @@ class HistoryClient(Client):
 
     def get_status(self, history_id):
         """
-        Returns the state of this history as a dictionary, with the following keys.
-        'state' = This is the current state of the history, such as ok, error, new etc.
-        'state_details' = Contains individual statistics for various dataset states.
-        'percent_complete' = The overall number of datasets processed to completion.
+        Returns the state of this history
+
+        :type history_id: str
+        :param history_id: Encoded history ID
+
+        :rtype: dict
+        :return: A dict documenting the current state of the history. Has the following keys:
+            'state' = This is the current state of the history, such as ok, error, new etc.
+            'state_details' = Contains individual statistics for various dataset states.
+            'percent_complete' = The overall number of datasets processed to completion.
         """
         state = {}
         history = self.show_history(history_id)

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -13,7 +13,6 @@ class HistoryClient(Client):
 
     def __init__(self, galaxy_instance):
         self.module = 'histories'
-        self.galaxy_instance = galaxy_instance
         super(HistoryClient, self).__init__(galaxy_instance)
 
     def create_history(self, name=None):
@@ -259,7 +258,7 @@ class HistoryClient(Client):
         Download a ``dataset_id`` from history with ``history_id`` to a
         file on the local file system, saving it to ``file_path``.
         """
-        dc = DatasetClient(self.galaxy_instance)
+        dc = DatasetClient(self.gi)
         return dc.download_dataset(dataset_id, file_path=file_path,
                                    use_default_filename=use_default_filename,
                                    file_ext=to_ext)

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -3,12 +3,9 @@ Contains possible interactions with the Galaxy Histories
 """
 import bioblend
 from bioblend.galaxy.client import Client
+from bioblend.galaxy.datasets import DatasetClient
 
-import os
 import re
-import shutil
-import urlparse
-import urllib2
 import time
 
 
@@ -16,6 +13,7 @@ class HistoryClient(Client):
 
     def __init__(self, galaxy_instance):
         self.module = 'histories'
+        self.galaxy_instance = galaxy_instance
         super(HistoryClient, self).__init__(galaxy_instance)
 
     def create_history(self, name=None):
@@ -261,26 +259,10 @@ class HistoryClient(Client):
         Download a ``dataset_id`` from history with ``history_id`` to a
         file on the local file system, saving it to ``file_path``.
         """
-        # TODO: Outsource to DatasetClient.download_dataset() to replace most of this.
-        meta = self.show_dataset(history_id, dataset_id)
-        d_type = to_ext
-        if d_type is None and 'file_ext' in meta:
-            d_type = meta['file_ext']
-        elif d_type is None and 'data_type' in meta:
-            d_type = meta['data_type']
-
-        # TODO: Download this via the REST API. api/datasets/<dataset_id>/display
-        download_url = 'datasets/' + meta['id'] + '/display?to_ext=' + d_type
-        url = urlparse.urljoin(self.gi.base_url, download_url)
-
-        req = urllib2.urlopen(url)
-        if use_default_filename:
-            file_local_path = os.path.join(file_path, meta['name'])
-        else:
-            file_local_path = file_path
-
-        with open(file_local_path, 'wb') as fp:
-            shutil.copyfileobj(req, fp)
+        dc = DatasetClient(self.galaxy_instance)
+        return dc.download_dataset(dataset_id, file_path=file_path,
+                                   use_default_filename=use_default_filename,
+                                   file_ext=to_ext)
 
     def delete_history(self, history_id, purge=False):
         """

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -14,15 +14,15 @@ class JobsClient(Client):
         """
         Get a list of jobs for current user
 
-        :type   state: string or list
+        :type   state: str or list
         :param  state: limit listing of jobs to those that match one of the included states. If none, all are returned.
         Valid Galaxy job states include:
         'new', 'upload', 'waiting', 'queued', 'running', 'ok', 'error', 'paused', 'deleted', 'deleted_new'
 
-        :type   tool_id: string or list
+        :type   tool_id: str or list
         :param  tool_id: limit listing of jobs to those that match one of the included tool_ids. If none, all are returned.
 
-        :type   history_id: string
+        :type   history_id: str
         :param  history_id: limit listing of jobs to those that match the history_id. If none, all are returned.
 
         :rtype:     list
@@ -50,7 +50,7 @@ class JobsClient(Client):
         """
         Display information on a single job from current user
 
-        :type job_id: string
+        :type job_id: str
         :param job_id: Specific job ID
 
         :rtype: dict
@@ -79,10 +79,10 @@ class JobsClient(Client):
         """
         Display the current state for a single job from current user.
 
-        :type job_id: string
+        :type job_id: str
         :param job_id: Specific job ID
 
-        :rtype: string
+        :rtype: str
         :return: State of single job with the following being valid values:
                  `new`, `queued`, `running`, `waiting`, `ok`. In case the
                  state cannot be retrived, an empty string is returned.
@@ -95,9 +95,10 @@ class JobsClient(Client):
         """
         Return jobs for current user based payload content
 
-        :type   payload: dict
-        :param  payload: Dictionary containing description of requested job. This is in the same format as
-        a request to POST /api/tools would take to initiate a job
+        :type   job_info: dict
+        :param  job_info: Dictionary containing description of requested job.
+          This is in the same format as a request to POST /api/tools would take
+          to initiate a job
 
         :rtype:     list
         :returns:   list of dictionaries containing summary job information of the jobs that match the requested job run

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -15,6 +15,18 @@ class LibraryClient(Client):
         Create a data library with the properties defined in the arguments.
         Return a list of JSON dicts, looking like so::
 
+        :type name: str
+        :param name: Name of the new data library
+
+        :type description: str
+        :param description: Optional data library description
+
+        :type synopsis: str
+        :param synopsis: Optional data library synopsis
+
+        :rtype: list
+        :return: List of dicts describing created library
+
             [{"id": "f740ab636b360a70",
               "name": "Library from bioblend",
               "url": "/api/libraries/f740ab636b360a70"}]
@@ -29,7 +41,10 @@ class LibraryClient(Client):
 
     def delete_library(self, library_id):
         """
-        Delete a data library identified by `library_id`.
+        Delete a data library
+
+        :type library_id: str
+        :param library_id: Encoded data library ID identifying the library to be deleted
 
         .. warning::
             Deleting a data library is irreversible - all of the data from
@@ -51,7 +66,7 @@ class LibraryClient(Client):
         :param library_id: library id where dataset is found in
 
         :type dataset_id: str
-        :param dataset_id: if of the dataset to be deleted
+        :param dataset_id: id of the dataset to be deleted
 
         :type purged: bool
         :param purged: Indicate that the dataset should be purged (permanently deleted)
@@ -72,6 +87,15 @@ class LibraryClient(Client):
         """
         Get details about a given library dataset. The required ``library_id``
         can be obtained from the datasets's library content details.
+
+        :type library_id: str
+        :param library_id: library id where dataset is found in
+
+        :type dataset_id: str
+        :param dataset_id: id of the dataset to be inspected
+
+        :rtype: dict
+        :return: A dictionary containing information about the dataset in the library
         """
         return self.__show_item(library_id, dataset_id)
 
@@ -79,12 +103,21 @@ class LibraryClient(Client):
         """
         Get details about a given folder. The required ``folder_id``
         can be obtained from the folder's library content details.
+
+        :type library_id: str
+        :param library_id: library id to inspect folders in
+
+        :type folder_id: str
+        :param folder_id: id of the folder to be inspected
         """
         return self.__show_item(library_id, folder_id)
 
     def _get_root_folder_id(self, library_id):
         """
         Find the root folder (i.e. '/') of a library.
+
+        :type library_id: str
+        :param library_id: library id to find root of
         """
         folders = self.show_library(library_id=library_id, contents=True)
         for f in folders:
@@ -94,6 +127,15 @@ class LibraryClient(Client):
     def create_folder(self, library_id, folder_name, description=None, base_folder_id=None):
         """
         Create a folder in a library.
+
+        :type library_id: str
+        :param library_id: library id to use
+
+        :type folder_name: str
+        :param folder_name: name of the new folder in the data library
+
+        :type description: str
+        :param description: description of the new folder in the data library
 
         :type base_folder_id: str
         :param base_folder_id: id of the folder where to create the new folder.
@@ -117,13 +159,20 @@ class LibraryClient(Client):
         or ``folder_id`` in data library with id ``library_id``. Provide only one
         argument: ``name`` or ``folder_id``, but not both.
 
-        For ``name`` specify the full path of the folder starting from the
-        library's root folder, e.g. ``/subfolder/subsubfolder``.
+        :type folder_id: str
+        :param folder_id: filter for folder by folder id
 
-        If ``deleted`` is set to ``True``, return folders that have been deleted.
+        :type name: str
+        :param name: filter for folder by name. For ``name`` specify the full
+                     path of the folder starting from the library's root
+                     folder, e.g. ``/subfolder/subsubfolder``.
 
-        Return a list of JSON formatted dicts each containing basic information
-        about a folder.
+        :type deleted: bool
+        :param deleted: If set to ``True``, return folders that have been
+                        deleted.
+
+        :rtype: dict
+        :return: list of dicts each containing basic information about a folder.
         """
         if folder_id is not None and name is not None:
             raise ValueError('Provide only one argument between name or folder_id, but not both')
@@ -142,11 +191,20 @@ class LibraryClient(Client):
         Get all the libraries or filter for specific one(s) via the provided name or ID.
         Provide only one argument: ``name`` or ``library_id``, but not both.
 
-        If ``name`` is set and multiple names match the given name, all the
-        libraries matching the argument will be returned.
+        :type library_id: str
+        :param library_id: filter for library by library id
 
-        Return a list of JSON formatted dicts each containing basic information
-        about a library.
+        :type name: str
+        :param name: If ``name`` is set and multiple names match the given
+                     name, all the libraries matching the argument will be
+                     returned.
+
+        :type deleted: bool
+        :param deleted: If set to ``True``, return libraries that have been
+                        deleted.
+
+        :rtype: dict
+        :return: list of dicts each containing basic information about a library.
         """
         if library_id is not None and name is not None:
             raise ValueError('Provide only one argument between name or library_id, but not both')
@@ -162,10 +220,14 @@ class LibraryClient(Client):
         """
         Get information about a library.
 
-        If want to get contents of the library (rather than just the library details),
-        set ``contents`` to ``True``.
+        :type library_id: str
+        :param library_id: filter for library by library id
 
-        Return a list of JSON formatted dicts containing library details.
+        :type contents: bool
+        :param contents: True if want to get contents of the library (rather than just the library details).
+
+        :rtype: list
+        :return: a list of dicts containing library details.
         """
         return Client._get(self, id=library_id, contents=contents)
 
@@ -220,9 +282,21 @@ class LibraryClient(Client):
         """
         Upload a file to a library from a URL.
 
+        :type library_id: str
+        :param library_id: id of the library where to place the uploaded file.
+          If not provided, the root library will be used
+
+        :type file_url: str
+        :param file_url: file to download to the library specified by ``library_id``
+
         :type folder_id: str
-        :param folder_id: id of the folder where to place the uploaded file.
-          If not provided, the root folder will be used
+        :param folder_id: id of the folder to download into
+
+        :type file_type: str
+        :param file_type: Galaxy file format name
+
+        :type dbkey: str
+        :param dbkey: Dbkey
         """
         # TODO: Is there a better way of removing self from locals?
         vars = locals().copy()
@@ -233,9 +307,21 @@ class LibraryClient(Client):
         """
         Upload pasted_contents to a data library as a new file.
 
+        :type library_id: str
+        :param library_id: id of the library where to place the uploaded file.
+          If not provided, the root library will be used
+
+        :type pasted_content: str
+        :param pasted_content: Content to upload into a file
+
         :type folder_id: str
-        :param folder_id: id of the folder where to place the uploaded file.
-          If not provided, the root folder will be used
+        :param folder_id: id of the folder to download into
+
+        :type file_type: str
+        :param file_type: Galaxy file format name
+
+        :type dbkey: str
+        :param dbkey: Dbkey
         """
         vars = locals().copy()
         del vars['self']
@@ -246,9 +332,21 @@ class LibraryClient(Client):
         """
         Read local file contents from file_local_path and upload data to a library.
 
+        :type library_id: str
+        :param library_id: id of the library where to place the uploaded file.
+          If not provided, the root library will be used
+
+        :type file_local_path: str
+        :param file_local_path: Serverside path to file to add to library
+
         :type folder_id: str
-        :param folder_id: id of the folder where to place the uploaded file.
-          If not provided, the root folder will be used
+        :param folder_id: id of the folder to download into
+
+        :type file_type: str
+        :param file_type: Galaxy file format name
+
+        :type dbkey: str
+        :param dbkey: Dbkey
         """
         vars = locals().copy()
         del vars['self']
@@ -266,6 +364,10 @@ class LibraryClient(Client):
           ``library_import_dir`` option configured in the ``config/galaxy.ini``
           configuration file.
 
+        :type library_id: str
+        :param library_id: id of the library where to place the uploaded file.
+          If not provided, the root library will be used
+
         :type server_dir: str
         :param server_dir: relative path of the subdirectory of
           ``library_import_dir`` to upload. All and only the files (i.e. no
@@ -275,6 +377,17 @@ class LibraryClient(Client):
         :type folder_id: str
         :param folder_id: id of the folder where to place the uploaded files.
           If not provided, the root folder will be used
+
+        :type file_type: str
+        :param file_type: Galaxy file format name
+
+        :type dbkey: str
+        :param dbkey: Dbkey
+
+        :type link_data_only: str
+        :param link_data_only: either 'copy_files' (default) or
+          'link_to_files'. Setting to 'link_to_files' symlinks instead of
+          copying the files
         """
         vars = locals().copy()
         del vars['self']
@@ -292,6 +405,10 @@ class LibraryClient(Client):
           ``allow_library_path_paste`` option set to ``True`` in the
           ``config/galaxy.ini`` configuration file.
 
+        :type library_id: str
+        :param library_id: id of the library where to place the uploaded file.
+          If not provided, the root library will be used
+
         :type filesystem_paths: str
         :param filesystem_paths: file paths on the Galaxy server to upload to
           the library, one file per line
@@ -300,10 +417,19 @@ class LibraryClient(Client):
         :param folder_id: id of the folder where to place the uploaded files.
           If not provided, the root folder will be used
 
+        :type file_type: str
+        :param file_type: Galaxy file format name
+
+        :type dbkey: str
+        :param dbkey: Dbkey
+
         :type link_data_only: str
         :param link_data_only: either 'copy_files' (default) or
           'link_to_files'. Setting to 'link_to_files' symlinks instead of
           copying the files
+
+        :type roles: str
+        :param roles: ???
         """
         vars = locals().copy()
         del vars['self']
@@ -313,9 +439,19 @@ class LibraryClient(Client):
         """
         Copy a Galaxy dataset into a library.
 
+        :type library_id: str
+        :param library_id: id of the library where to place the uploaded file.
+          If not provided, the root library will be used
+
+        :type dataset_id: str
+        :param dataset_id: id of the dataset to copy from
+
         :type folder_id: str
         :param folder_id: id of the folder where to place the uploaded files.
           If not provided, the root folder will be used
+
+        :type message: str
+        :param message: message for copying action
         """
         if folder_id is None:
             folder_id = self._get_root_folder_id(library_id)
@@ -332,7 +468,20 @@ class LibraryClient(Client):
         Sets the permissions for a library.  Note: it will override all
         security for this library even if you leave out a permission type.
 
-        access_in, modify_in, add_in, manage_in expect a list of user id's OR None
+        :type library_id: str
+        :param library_id: id of the library
+
+        :type access_in: list
+        :param access_in: list of user ids
+
+        :type modify_in: list
+        :param modify_in: list of user ids
+
+        :type add_in: list
+        :param add_in: list of user ids
+
+        :type manage_in: list
+        :param manage_in: list of user ids
         """
 
         payload = {}

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -388,6 +388,9 @@ class LibraryClient(Client):
         :param link_data_only: either 'copy_files' (default) or
           'link_to_files'. Setting to 'link_to_files' symlinks instead of
           copying the files
+
+        :type roles: str
+        :param roles: ???
         """
         vars = locals().copy()
         del vars['self']

--- a/bioblend/galaxy/quotas/__init__.py
+++ b/bioblend/galaxy/quotas/__init__.py
@@ -14,9 +14,8 @@ class QuotaClient(Client):
         """
         Get a list of quotas
 
-        :type deleted: Boolean
+        :type deleted: bool
         :param deleted: Only return quota(s) that have been deleted
-
 
         :rtype: list
         :return: A list of dicts with details on individual quotas.
@@ -39,12 +38,11 @@ class QuotaClient(Client):
         """
         Display information on a quota
 
-        :type quota_id: string
+        :type quota_id: str
         :param quota_id: Encoded quota ID
 
-        :type deleted: Boolean
+        :type deleted: bool
         :param deleted: Search for quota in list of ones already marked as deleted
-
 
         :rtype: dict
         :return: A description of quota

--- a/bioblend/galaxy/roles/__init__.py
+++ b/bioblend/galaxy/roles/__init__.py
@@ -34,7 +34,7 @@ class RolesClient(Client):
         """
         Display information on a single role
 
-        :type role_id: string
+        :type role_id: str
         :param role_id: Encoded role ID
 
         :rtype: dict

--- a/bioblend/galaxy/tool_data/__init__.py
+++ b/bioblend/galaxy/tool_data/__init__.py
@@ -35,7 +35,7 @@ class ToolDataClient(Client):
         """
         Display information on a single data_table
 
-        :type data_table_id: string
+        :type data_table_id: str
         :param data_table_id: ID of the data table
 
         :rtype: dict
@@ -61,8 +61,12 @@ class ToolDataClient(Client):
         """
         Delete an item from a data table.
 
-        The ``values`` is a "|" separated list of column contents,
-        there must be a value for all the columns of the data table
+        :type data_table_id: str
+        :param data_table_id: ID of the data table
+
+        :type values: str
+        :param values: a "|" separated list of column contents, there must be a
+          value for all the columns of the data table
         """
         payload = {}
         payload['values'] = values

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -68,10 +68,10 @@ class ToolClient(Client):
         :type tool_id: str
         :param tool_id: id of the requested tool
 
-        :type io_details: boolean
+        :type io_details: bool
         :param io_details: if True, get also input and output details
 
-        :type link_details: boolean
+        :type link_details: bool
         :param link_details: if True, get also link details
         """
         params = {}
@@ -83,6 +83,12 @@ class ToolClient(Client):
         """
         Runs tool specified by ``tool_id`` in history indicated
         by ``history_id`` with inputs from ``dict`` ``tool_inputs``.
+
+        :type history_id: str
+        :param history_id: encoded ID of the history in which to run the tool
+
+        :type tool_id: str
+        :param tool_id: ID of the tool to be run
 
         :type tool_inputs: dict
         :param tool_inputs: dictionary of input datasets and parameters
@@ -113,11 +119,10 @@ class ToolClient(Client):
         :param history_id: id of the history where to upload the file
 
         :type file_name: str
-        :param file_name: (optional) name of the new history dataset
+        :param file_name: name of the new history dataset
 
         :type file_type: str
-        :param file_type: (optional) Galaxy datatype for the new dataset,
-          default is auto
+        :param file_type: Galaxy datatype for the new dataset, default is auto
 
         :type dbkey: str
         :param dbkey: (optional) genome dbkey

--- a/bioblend/galaxy/toolshed/__init__.py
+++ b/bioblend/galaxy/toolshed/__init__.py
@@ -37,7 +37,7 @@ class ToolShedClient(Client):
         """
         Display information of a repository from the Tool Shed
 
-        :type toolShed_id: string
+        :type toolShed_id: str
         :param toolShed_id: Encoded toolShed ID
 
         :rtype: dictionary
@@ -77,32 +77,32 @@ class ToolShedClient(Client):
             <section id="from_test_tool_shed" name="From Test Tool Shed" version="">
             </section>
 
-        :type tool_shed_url: string
+        :type tool_shed_url: str
         :param tool_shed_url: URL of the Tool Shed from which the repository should
                               be installed from (e.g., ``http://testtoolshed.g2.bx.psu.edu``)
 
-        :type name: string
+        :type name: str
         :param name: The name of the repository that should be installed
 
-        :type owner: string
+        :type owner: str
         :param owner: The name of the repository owner
 
-        :type changeset_revision: string
+        :type changeset_revision: str
         :param changeset_revision: The revision of the repository to be installed
 
-        :type install_tool_dependencies: Boolean
+        :type install_tool_dependencies: bool
         :param install_tool_dependencies: Whether or not to automatically handle
                                           tool dependencies (see
                                           http://wiki.galaxyproject.org/AToolOrASuitePerRepository
                                           for more details)
 
-        :type install_repository_dependencies: Boolean
+        :type install_repository_dependencies: bool
         :param install_repository_dependencies: Whether or not to automatically
                                                 handle repository dependencies
                                                 (see http://wiki.galaxyproject.org/DefiningRepositoryDependencies
                                                 for more details)
 
-        :type tool_panel_section_id: string
+        :type tool_panel_section_id: str
         :param tool_panel_section_id: The ID of the Galaxy tool panel section
                                       where the tool should be insterted under.
                                       Note that you should specify either this
@@ -110,7 +110,7 @@ class ToolShedClient(Client):
                                       If both are specified, this one will take
                                       precedence.
 
-        :type new_tool_panel_section_label: string
+        :type new_tool_panel_section_label: str
         :param new_tool_panel_section_label: The name of a Galaxy tool panel section
                                              that should be created and the repository
                                              installed into.

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -32,6 +32,15 @@ class UserClient(Client):
         """
         Display information about a user. If ``deleted`` is set to ``True``,
         display information about a deleted user.
+
+        :type user_id: str
+        :param user_id: User ID to inspect
+
+        :type deleted: bool
+        :param deleted: Include deleted users in listing
+
+        :rtype: dict
+        :return: dictionary containing information about the user
         """
         return Client._get(self, id=user_id, deleted=deleted)
 
@@ -40,6 +49,12 @@ class UserClient(Client):
         Deprecated method.
 
         Just an alias for create_remote_user().
+
+        :type user_email: str
+        :param user_email: Email of user to be created
+
+        :rtype: dict
+        :return: dictionary containing information about the user
         """
         return self.create_remote_user(user_email)
 
@@ -54,6 +69,12 @@ class UserClient(Client):
           note that setting ``use_remote_user`` will require an upstream
           authentication proxy server; however, if you do not have one, access
           to Galaxy via a browser will not be possible.
+
+        :type user_email: str
+        :param user_email: Email of user to be created
+
+        :rtype: dict
+        :return: dictionary containing information about the user
         """
         payload = {}
         payload['remote_user_email'] = user_email
@@ -68,6 +89,18 @@ class UserClient(Client):
           ``allow_user_creation`` option set to ``True`` and
           ``use_remote_user`` option set to ``False`` in the
           ``config/galaxy.ini`` configuration file.
+
+        :type username: str
+        :param username: Username of user to be created
+
+        :type user_email: str
+        :param user_email: Email of user to be created
+
+        :type password: str
+        :param password: password of user to be created
+
+        :rtype: dict
+        :return: dictionary containing information about the user
         """
         payload = {}
         payload['username'] = username
@@ -78,6 +111,9 @@ class UserClient(Client):
     def get_current_user(self):
         """
         Returns the user id associated with this Galaxy connection
+
+        :rtype: dict
+        :return: dictionary containing information about the current user
         """
         url = self.gi._make_url(self, None)
         url = '/'.join([url, 'current'])
@@ -87,10 +123,10 @@ class UserClient(Client):
         """
         Create a new api key for a user
 
-        :type user_id: string
+        :type user_id: str
         :param user_id: Encoded user ID
 
-        :rtype: string
+        :rtype: str
         :return: The api key for the user
         """
 

--- a/bioblend/galaxy/visual/__init__.py
+++ b/bioblend/galaxy/visual/__init__.py
@@ -38,7 +38,7 @@ class VisualClient(Client):
         """
         Display information on a visualization
 
-        :type visual_id: string
+        :type visual_id: str
         :param visual_id: Encoded visualization ID
 
         :rtype: dict

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -16,15 +16,20 @@ class WorkflowClient(Client):
         or ``workflow_id``. Provide only one argument, ``name`` or ``workflow_id``,
         but not both.
 
-        If ``name`` is set and multiple names match the given name, all the
-        workflows matching the argument will be returned.
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID (incompatible with ``name``)
 
-        If ``deleted`` is set to ``True``, return workflows that have been deleted.
+        :type name: str
+        :param name: Filter by name of workflow (incompatible with
+          ``workflow_id``). If multiple names match the given name, all the
+          workflows matching the argument will be returned.
 
-        If ``published`` is set to ``True``, return published workflows.
+        :type deleted: bool
+        :param deleted: If set to ``True``, return workflows that have been
+          deleted.
 
-        Return a list of JSON formatted dicts each containing basic information
-        about a workflow.
+        :type published: bool
+        :param published: If set to ``True``, return published workflows.
 
         :rtype: list
         :return: A list of workflow dicts.
@@ -52,7 +57,7 @@ class WorkflowClient(Client):
         """
         Display information needed to run a workflow
 
-        :type workflow_id: string
+        :type workflow_id: str
         :param workflow_id: Encoded workflow ID
 
         :rtype: list
@@ -71,6 +76,15 @@ class WorkflowClient(Client):
         """
         Get a list of workflow input IDs that match the given label.
         If no input matches the given label, an empty list is returned.
+
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
+
+        :type label: str
+        :param label: label to filter workflow inputs on
+
+        :rtype: list
+        :return: list of workflow inputs matching the label query
         """
         wf = Client._get(self, id=workflow_id)
         inputs = wf['inputs']
@@ -80,6 +94,9 @@ class WorkflowClient(Client):
         """
         Imports a new workflow given a json representation of a previously exported
         workflow.
+
+        :type workflow_json: str
+        :param workflow_json: JSON string representing the workflow to be imported
         """
         payload = {}
         payload['workflow'] = workflow_json
@@ -92,6 +109,9 @@ class WorkflowClient(Client):
         """
         Imports a new workflow given the path to a file containing a previously
         exported workflow.
+
+        :type file_local_path: str
+        :param file_local_path: File to upload to the server for new workflow
         """
         with open(file_local_path, 'rb') as fp:
             workflow_json = json.load(fp)
@@ -102,10 +122,10 @@ class WorkflowClient(Client):
         """
         Imports a new workflow from the shared published workflows
 
-        :type workflow_id: string
+        :type workflow_id: str
         :param workflow_id: Encoded workflow ID
 
-        :rtype: Dict
+        :rtype: dict
         :return: A description of the workflow.
                  For example::
 
@@ -125,10 +145,13 @@ class WorkflowClient(Client):
 
     def export_workflow_json(self, workflow_id):
         """
-        Exports a workflow in json format
+        Exports a workflow
 
-        :type workflow_id: string
+        :type workflow_id: str
         :param workflow_id: Encoded workflow ID
+
+        :rtype: dict
+        :return: Dict representing the workflow requested
         """
         url = self.gi._make_url(self)
         url = '/'.join([url, "download"])
@@ -137,21 +160,20 @@ class WorkflowClient(Client):
 
     def export_workflow_to_local_path(self, workflow_id, file_local_path, use_default_filename=True):
         """
-        Exports a workflow in json format to a given local path.
+        Exports a workflow to a given local path.
 
-        :type workflow_id: string
+        :type workflow_id: str
         :param workflow_id: Encoded workflow ID
 
-        :type file_local_path: string
+        :type file_local_path: str
         :param file_local_path: Local path to which the exported file will be saved.
                                 (Should not contain filename if use_default_name=True)
 
-        :type use_default_name: boolean
-        :param use_default_name: If the use_default_name parameter is True, the exported
-                                 file will be saved as file_local_path/Galaxy-Workflow-%s.ga,
-                                 where %s is the workflow name.
-                                 If use_default_name is False, file_local_path is assumed to
-                                 contain the full file path including filename.
+        :type use_default_filename: bool
+        :param use_default_filename: If the use_default_name parameter is True, the exported
+          file will be saved as file_local_path/Galaxy-Workflow-%s.ga, where %s
+          is the workflow name. If use_default_name is False, file_local_path
+          is assumed to contain the full file path including filename.
         """
         workflow_json = self.export_workflow_json(workflow_id)
 
@@ -167,10 +189,10 @@ class WorkflowClient(Client):
         """
         Run the workflow identified by ``workflow_id``
 
-        :type workflow_id: string
+        :type workflow_id: str
         :param workflow_id: Encoded workflow ID
 
-        :type dataset_map: string or dict
+        :type dataset_map: str or dict
         :param dataset_map: A mapping of workflow inputs to datasets. The datasets
                             source can be a LibraryDatasetDatasetAssociation (``ldda``),
                             LibraryDataset (``ld``), or HistoryDatasetAssociation (``hda``).
@@ -178,16 +200,16 @@ class WorkflowClient(Client):
                             ``{'<input>': {'id': <encoded dataset ID>, 'src': '[ldda, ld, hda]'}}``
                             (e.g. ``{'23': {'id': '29beef4fadeed09f', 'src': 'ld'}}``)
 
-        :type params: string or dict
+        :type params: str or dict
         :param params: A mapping of tool parameters that are non-datasets parameters. The map must be in the
                          following format:
                          ``{'blastn': {'param': 'evalue', 'value': '1e-06'}}``
 
-        :type history_id: string
+        :type history_id: str
         :param history_id: The encoded history ID where to store the workflow output.
                            ``history_id`` OR ``history_name`` should be provided but not both!
 
-        :type history_name: string
+        :type history_name: str
         :param history_name: Create a new history with the given name to store the
                              workflow output. ``history_id`` OR ``history_name``
                              should be provided but not both!
@@ -248,6 +270,9 @@ class WorkflowClient(Client):
     def delete_workflow(self, workflow_id):
         """
         Delete a workflow identified by `workflow_id`.
+
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
 
         .. warning::
             Deleting a workflow is irreversible - all workflow data


### PR DESCRIPTION
Modify bioblend.galaxy.histories to implement TODOs, fix dataset URL by downloading from url provided by show_datasets() call.

This doesn't pass test cases on my desktop (but then again, reverting to the parent commit also didn't let it pass tests), so I'm going to let Travis test it and rely on those test results.

There is a small behaviour change here:

| file_path | use_default_filename | original output | new output
--- | --- | --- | ----
`str` (folder) | True | None | return path the file was saved to, rather than leaving the user guessing/calculating
`str` (file) | False| None | return the user requested path that the file was saved to
None | True or False | file contents | file contents

The other small behaviour change being that `download_dataset` in `bioblend.galaxy.histories` now returns the value of the call from `bioblend.galaxy.datasets` rather than `None`. 

Lastly, `HistoryClient.download_dataset` now ignores `history_id`, as that isn't actually needed to download a dataset.