### PR TITLE
API break: remove 'deleted' parameter from WorkflowClient.get_workflows() and ObjWorkflowClient.list()

### DIFF
--- a/bioblend/galaxy/objects/client.py
+++ b/bioblend/galaxy/objects/client.py
@@ -277,7 +277,8 @@ class ObjWorkflowClient(ObjClient):
             )
         return [wrappers.WorkflowPreview(_, gi=self.obj_gi) for _ in dicts]
 
-    def list(self, name=None, deleted=False, published=False):
+    # the 'deleted' option is not available for workflows
+    def list(self, name=None, published=False):
         """
         Get workflows owned by the user of this Galaxy instance.
 
@@ -289,7 +290,7 @@ class ObjWorkflowClient(ObjClient):
         :rtype: list of :class:`~.wrappers.Workflow`
         """
         dicts = self.gi.workflows.get_workflows(
-            name=name, deleted=deleted, published=published
+            name=name, published=published
             )
         return [self.get(_['id']) for _ in dicts]
 

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -10,7 +10,7 @@ class WorkflowClient(Client):
         self.module = 'workflows'
         super(WorkflowClient, self).__init__(galaxy_instance)
 
-    def get_workflows(self, workflow_id=None, name=None, deleted=False, published=False):
+    def get_workflows(self, workflow_id=None, name=None, published=False):
         """
         Get all workflows or filter the specific one(s) via the provided ``name``
         or ``workflow_id``. Provide only one argument, ``name`` or ``workflow_id``,
@@ -18,8 +18,6 @@ class WorkflowClient(Client):
 
         If ``name`` is set and multiple names match the given name, all the
         workflows matching the argument will be returned.
-
-        If ``deleted`` is set to ``True``, return workflows that have been deleted.
 
         If ``published`` is set to ``True``, return published workflows.
 
@@ -37,7 +35,7 @@ class WorkflowClient(Client):
         """
         if workflow_id is not None and name is not None:
             raise ValueError('Provide only one argument between name or workflow_id, but not both')
-        kwargs = {'deleted': deleted}
+        kwargs = {}
         if published:
             kwargs['params'] = {'show_published': 'True'}
         workflows = Client._get(self, **kwargs)


### PR DESCRIPTION
Passing ```deleted=True``` to this methods has never worked since workflows are just permanently deleted.

This may break scripts calling these methods with positional arguments. Alternatively I can leave the parameter in place, but not pass it to Galaxy and deprecate it in the methods documentation.

@afgane @simleo Opinions?