### PR TITLE
Missing brackets in API url parameter

### DIFF
--- a/bioblend/toolshed/repositories/__init__.py
+++ b/bioblend/toolshed/repositories/__init__.py
@@ -323,6 +323,6 @@ class ToolShedClient(Client):
             payload['homepage_url'] = homepage_url
 
         if category_ids is not None:
-            payload['category_ids'] = category_ids
+            payload['category_ids[]'] = category_ids
 
         return Client._post(self, payload)


### PR DESCRIPTION
I misread https://github.com/galaxyproject/galaxy/pull/2 and failed to notice the `[]` at the end of `category_ids`.