### PR TITLE
Do not swallow KeyboardInterrupt and SystemExit in Python 2

### DIFF
--- a/bioblend/__init__.py
+++ b/bioblend/__init__.py
@@ -9,6 +9,8 @@ __version__ = '0.5.4-dev'
 try:
     import resource
     CHUNK_SIZE = resource.getpagesize()
+except (KeyboardInterrupt, SystemExit):  # for Python 2
+    raise
 except Exception:
     CHUNK_SIZE = 4096
 

--- a/bioblend/cloudman/launch.py
+++ b/bioblend/cloudman/launch.py
@@ -169,6 +169,8 @@ class CloudManLauncher(object):
                 bioblend.log.info("Launched an instance with ID %s" % rs.instances[0].id)
                 ret['instance_id'] = rs.instances[0].id
                 ret['instance_ip'] = rs.instances[0].ip_address
+            except (KeyboardInterrupt, SystemExit):  # for Python 2
+                raise
             except Exception as e:
                 bioblend.log.exception("Problem with the launched instance object.")
                 ret['error'] = "Problem with the launched instance object: %s" % e
@@ -317,6 +319,8 @@ class CloudManLauncher(object):
                         state['instance_state'] = 'booting'
                 else:
                     state['instance_state'] = inst_state
+        except (KeyboardInterrupt, SystemExit):  # for Python 2
+            raise
         except Exception as e:
             err = "Problem updating instance '%s' state: %s" % (instance_id, e)
             bioblend.log.error(err)
@@ -520,6 +524,8 @@ class CloudManLauncher(object):
                         # No need to continue to iterate through
                         # filesystems, if we found one with a volume.
                         break
+            except (KeyboardInterrupt, SystemExit):  # for Python 2
+                raise
             except Exception:
                 bioblend.log.exception("Exception while finding placement.  This can indicate malformed instance data.  Or that this method is broken.")
                 placement = None
@@ -582,6 +588,8 @@ class CloudManLauncher(object):
             r = h.getreply()
             if r[0] == 200 or r[0] == 401:  # CloudMan UI is pwd protected so include 401
                 return True
+        except (KeyboardInterrupt, SystemExit):  # for Python 2
+            raise
         except Exception:
             # No response or no good response
             pass

--- a/bioblend/galaxy/objects/galaxy_instance.py
+++ b/bioblend/galaxy/objects/galaxy_instance.py
@@ -21,6 +21,8 @@ def _get_error_info(hda):
     try:
         msg += ' (%s): ' % hda.name
         msg += hda.wrapped['misc_info']
+    except (KeyboardInterrupt, SystemExit):  # for Python 2
+        raise
     except Exception:  # avoid 'error while generating an error report'
         msg += ': error'
     return msg


### PR DESCRIPTION
In the course of the ongoing work on Python 3 support (see #131), some `except StandardError` have been replaced by `except Exception`. In Python2, however, this is a bit dangerous as it swallows up `KeyboardInterrupt` and `SystemExit`, which could lead to unexpected hangs. This PR should fix this problem (and be harmless albeit useless in Python 3).