### PR TITLE
Fix handling of strings and binary data for future Python3 support.

### DIFF
--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -509,7 +509,7 @@ class HistoryClient(Client):
           :meth:`export_history`)
 
         :type outf: file
-        :param outf: output file object, open for writing
+        :param outf: output file object, open for writing in binary mode
 
         :type chunk_size: int
         :param chunk_size: how many bytes at a time should be read into memory

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -529,7 +529,7 @@ class Dataset(Wrapper):
         try:
             return next(self.get_stream(chunk_size=chunk_size))
         except StopIteration:
-            return ''
+            return b''
 
     def download(self, file_object, chunk_size=bioblend.CHUNK_SIZE):
         """
@@ -549,7 +549,7 @@ class Dataset(Wrapper):
 
         See :meth:`.get_stream` for param info.
         """
-        return ''.join(self.get_stream(chunk_size=chunk_size))
+        return b''.join(self.get_stream(chunk_size=chunk_size))
 
     def refresh(self):
         """

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -114,7 +114,7 @@ class WorkflowClient(Client):
         :type file_local_path: str
         :param file_local_path: File to upload to the server for new workflow
         """
-        with open(file_local_path, 'rb') as fp:
+        with open(file_local_path, 'r') as fp:
             workflow_json = json.load(fp)
 
         return self.import_workflow_json(workflow_json)
@@ -182,7 +182,7 @@ class WorkflowClient(Client):
             filename = 'Galaxy-Workflow-%s.ga' % workflow_json['name']
             file_local_path = os.path.join(file_local_path, filename)
 
-        with open(file_local_path, 'wb') as fp:
+        with open(file_local_path, 'w') as fp:
             json.dump(workflow_json, fp)
 
     def run_workflow(self, workflow_id, dataset_map=None, params=None,

--- a/tests/TestGalaxyDatasets.py
+++ b/tests/TestGalaxyDatasets.py
@@ -30,7 +30,7 @@ class TestGalaxyDatasets(GalaxyTestBase.GalaxyTestBase):
         with tempfile.NamedTemporaryFile(prefix='bioblend_test_') as f:
             self.gi.datasets.download_dataset(self.dataset_id, file_path=f.name, use_default_filename=False)
             f.flush()
-            self.assertEqual(f.read(), "1\t2\t3\n")
+            self.assertEqual(f.read(), b"1\t2\t3\n")
 
     def test_show_stderr(self):
         stderr = self.gi.datasets.show_stderr(self.dataset_id)

--- a/tests/TestGalaxyHistories.py
+++ b/tests/TestGalaxyHistories.py
@@ -104,7 +104,7 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
     def test_download_dataset(self):
         history_id = self.history["id"]
         dataset1_id = self._test_dataset(history_id)
-        self._wait_and_verify_dataset(history_id, dataset1_id, "1\t2\t3\n")
+        self._wait_and_verify_dataset(history_id, dataset1_id, b"1\t2\t3\n")
 
     def test_delete_history(self):
         result = self.gi.histories.delete_history(self.history['id'])
@@ -140,7 +140,7 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
         tempdir = tempfile.mkdtemp(prefix='bioblend_test_')
         temp_fn = os.path.join(tempdir, 'export.tar.gz')
         try:
-            with open(temp_fn, 'w') as fo:
+            with open(temp_fn, 'wb') as fo:
                 self.gi.histories.download_history(self.history['id'], jeha_id,
                                                    fo)
             self.assertTrue(tarfile.is_tarfile(temp_fn))

--- a/tests/TestGalaxyLibraries.py
+++ b/tests/TestGalaxyLibraries.py
@@ -46,7 +46,7 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
         self.gi.libraries.upload_file_contents(self.library['id'], FOO_DATA)
 
     def test_upload_file_from_local_path(self):
-        with tempfile.NamedTemporaryFile(prefix='bioblend_test_') as f:
+        with tempfile.NamedTemporaryFile(mode='w', prefix='bioblend_test_') as f:
             f.write(FOO_DATA)
             f.flush()
             self.gi.libraries.upload_file_from_local_path(self.library['id'], f.name)

--- a/tests/TestGalaxyObjects.py
+++ b/tests/TestGalaxyObjects.py
@@ -11,6 +11,7 @@ import uuid
 
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import URLError
+import six
 
 import bioblend
 bioblend.set_stream_logger('test', level='INFO')
@@ -441,7 +442,7 @@ class TestLibrary(GalaxyObjectsTestBase):
             print("skipped 'url not reachable'")
 
     def test_dataset_from_local(self):
-        with tempfile.NamedTemporaryFile(prefix='bioblend_test_') as f:
+        with tempfile.NamedTemporaryFile(mode='w', prefix='bioblend_test_') as f:
             f.write(FOO_DATA)
             f.flush()
             ds = self.lib.upload_from_local(f.name)
@@ -497,23 +498,23 @@ class TestLDContents(GalaxyObjectsTestBase):
     @test_util.skip_unless_galaxy('release_14.08')
     def test_dataset_get_stream(self):
         for idx, c in enumerate(self.ds.get_stream(chunk_size=1)):
-            self.assertEqual(str(FOO_DATA[idx]), c)
+            self.assertEqual(six.b(FOO_DATA[idx]), c)
 
     @test_util.skip_unless_galaxy('release_14.08')
     def test_dataset_peek(self):
         fetched_data = self.ds.peek(chunk_size=4)
-        self.assertEqual(FOO_DATA[0:4], fetched_data)
+        self.assertEqual(six.b(FOO_DATA[0:4]), fetched_data)
 
     @test_util.skip_unless_galaxy('release_14.08')
     def test_dataset_download(self):
         with tempfile.TemporaryFile() as f:
             self.ds.download(f)
             f.seek(0)
-            self.assertEqual(FOO_DATA, f.read())
+            self.assertEqual(six.b(FOO_DATA), f.read())
 
     @test_util.skip_unless_galaxy('release_14.08')
     def test_dataset_get_contents(self):
-        self.assertEqual(FOO_DATA, self.ds.get_contents())
+        self.assertEqual(six.b(FOO_DATA), self.ds.get_contents())
 
     def test_dataset_delete(self):
         self.ds.delete()
@@ -559,7 +560,7 @@ class TestHistory(GalaxyObjectsTestBase):
         self.__check_dataset(hda)
 
     def test_upload_file(self):
-        with tempfile.NamedTemporaryFile(prefix='bioblend_test_') as f:
+        with tempfile.NamedTemporaryFile(mode='w', prefix='bioblend_test_') as f:
             f.write(FOO_DATA)
             f.flush()
             hda = self.hist.upload_file(f.name)
@@ -593,7 +594,7 @@ class TestHistory(GalaxyObjectsTestBase):
         tempdir = tempfile.mkdtemp(prefix='bioblend_test_')
         temp_fn = os.path.join(tempdir, 'export.tar.gz')
         try:
-            with open(temp_fn, 'w') as fo:
+            with open(temp_fn, 'wb') as fo:
                 self.hist.download(jeha_id, fo)
             self.assertTrue(tarfile.is_tarfile(temp_fn))
         finally:
@@ -624,21 +625,21 @@ class TestHDAContents(GalaxyObjectsTestBase):
 
     def test_dataset_get_stream(self):
         for idx, c in enumerate(self.ds.get_stream(chunk_size=1)):
-            self.assertEqual(str(FOO_DATA[idx]), c)
+            self.assertEqual(six.b(FOO_DATA[idx]), c)
 
     def test_dataset_peek(self):
         fetched_data = self.ds.peek(chunk_size=4)
-        self.assertEqual(FOO_DATA[0:4], fetched_data)
+        self.assertEqual(six.b(FOO_DATA[0:4]), fetched_data)
 
     def test_dataset_download(self):
         with tempfile.TemporaryFile() as f:
             self.ds.download(f)
             f.seek(0)
             data = f.read()
-            self.assertEqual(FOO_DATA, data)
+            self.assertEqual(six.b(FOO_DATA), data)
 
     def test_dataset_get_contents(self):
-        self.assertEqual(FOO_DATA, self.ds.get_contents())
+        self.assertEqual(six.b(FOO_DATA), self.ds.get_contents())
 
     def test_dataset_delete(self):
         self.ds.delete()

--- a/tests/TestGalaxyWorkflows.py
+++ b/tests/TestGalaxyWorkflows.py
@@ -33,7 +33,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         dir_contents = os.listdir(export_dir)
         self.assertEqual(len(dir_contents), 1)
         export_path = os.path.join(export_dir, dir_contents[0])
-        with open(export_path, 'rb') as f:
+        with open(export_path, 'r') as f:
             workflow_json = json.load(f)
         self.assertIsInstance(workflow_json, dict)
         shutil.rmtree(export_dir)


### PR DESCRIPTION
Another step for issue #97 .

After this, just 19 errors left (all due to dictionary iterator methods) in Travis on Python 3.