### PR TITLE
Verify SSL certificates by default.

### DIFF
--- a/bioblend/galaxy/__init__.py
+++ b/bioblend/galaxy/__init__.py
@@ -57,7 +57,7 @@ class GalaxyInstance(GalaxyClient):
         self.url = urljoin(url, 'api')
         self._init_auth(key, email, password)
         self.json_headers = {'Content-Type': 'application/json'}
-        self.verify = False  # Should SSL verification be done
+        self.verify = True  # Should SSL verification be done
         self.libraries = libraries.LibraryClient(self)
         self.histories = histories.HistoryClient(self)
         self.workflows = workflows.WorkflowClient(self)

--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -104,7 +104,7 @@ class DatasetClient(Client):
 
         # Don't use self.gi.make_get_request as currently the download API does
         # not require a key
-        r = requests.get(url)
+        r = requests.get(url, verify=self.gi.verify)
 
         if file_path is None:
             return r.content

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -142,7 +142,7 @@ class GalaxyClient(object):
             params = self.default_params
 
         payload = json.dumps(payload)
-        r = requests.put(url, data=payload, params=params)
+        r = requests.put(url, verify=self.verify, data=payload, params=params)
         return r
 
     @property

--- a/bioblend/toolshed/__init__.py
+++ b/bioblend/toolshed/__init__.py
@@ -41,5 +41,5 @@ class ToolShedInstance(GalaxyClient):
         self.url = urljoin(url, 'api')
         self._init_auth(key, email, password)
         self.json_headers = {'Content-Type': 'application/json'}
-        self.verify = False  # Should SSL verification be done
+        self.verify = True  # Should SSL verification be done
         self.repositories = repositories.ToolShedClient(self)


### PR DESCRIPTION
I think we should stay on the safe side, also [requests](http://python-requests.org/) has [SSL cert verification](http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification) set to True by default.