### PR TITLE
Build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ ignore = E501
 
 [nosetests]
 verbosity=2
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Since BioBlend is Python 3 compatible, its wheels can be "universal".