### PR TITLE
Adds subnet_id to launch method.

### DIFF
--- a/bioblend/cloudman/launch.py
+++ b/bioblend/cloudman/launch.py
@@ -110,7 +110,7 @@ class CloudManLauncher(object):
 
     def launch(self, cluster_name, image_id, instance_type, password,
                kernel_id=None, ramdisk_id=None, key_name='cloudman_key_pair',
-               security_groups=['CloudMan'], placement='',subnet_id=None, **kwargs):
+               security_groups=['CloudMan'], placement='', subnet_id=None, **kwargs):
         """
         Check all the prerequisites (key pair and security groups) for
         launching a CloudMan instance, compose the user data based on the
@@ -173,7 +173,6 @@ class CloudManLauncher(object):
             rs = self.ec2_conn.run_instances(image_id=image_id,
                                              instance_type=instance_type,
                                              key_name=key_name,
-                                             #security_groups=security_groups,
                                              security_group_ids=security_group_ids,
                                              user_data=ud,
                                              kernel_id=kernel_id,
@@ -260,7 +259,7 @@ class CloudManLauncher(object):
                 cmsg = self.ec2_conn.create_security_group(sg_name, 'A security '
                                                            'group for CloudMan')
             except EC2ResponseError as e:
-                err_msg = "Problem creaInvalid value 'null' for protocol. VPC security group rules must specify protocols explicitlyting security group '{0}': {1} (code {2}; " \
+                err_msg = "Problem creating security group '{0}': {1} (code {2}; " \
                           "status {3})" \
                           .format(sg_name, e.message, e.error_code, e.status)
                 bioblend.log.exception(err_msg)

--- a/bioblend/cloudman/launch.py
+++ b/bioblend/cloudman/launch.py
@@ -110,7 +110,7 @@ class CloudManLauncher(object):
 
     def launch(self, cluster_name, image_id, instance_type, password,
                kernel_id=None, ramdisk_id=None, key_name='cloudman_key_pair',
-               security_groups=['CloudMan'], placement='', **kwargs):
+               security_groups=['CloudMan'], placement='',subnet_id=None, **kwargs):
         """
         Check all the prerequisites (key pair and security groups) for
         launching a CloudMan instance, compose the user data based on the
@@ -132,11 +132,13 @@ class CloudManLauncher(object):
         ``error`` containing an error message if there was one.
         """
         ret = {'sg_names': [],
+               'sg_ids': [],
                'kp_name': '',
                'kp_material': '',
                'rs': None,
                'instance_id': '',
                'error': None}
+        security_group_ids = []
         # First satisfy the prerequisites
         for sg in security_groups:
             cmsg = self.create_cm_security_group(sg)
@@ -145,6 +147,8 @@ class CloudManLauncher(object):
                 return ret
             if cmsg['name']:
                 ret['sg_names'].append(cmsg['name'])
+                ret['sg_ids'].append(cmsg['sg_id'])
+                security_group_ids.append(cmsg['sg_id'])
         kp_info = self.create_key_pair(key_name)
         ret['error'] = kp_info['error']
         if ret['error']:
@@ -169,10 +173,12 @@ class CloudManLauncher(object):
             rs = self.ec2_conn.run_instances(image_id=image_id,
                                              instance_type=instance_type,
                                              key_name=key_name,
-                                             security_groups=security_groups,
+                                             #security_groups=security_groups,
+                                             security_group_ids=security_group_ids,
                                              user_data=ud,
                                              kernel_id=kernel_id,
                                              ramdisk_id=ramdisk_id,
+                                             subnet_id=subnet_id,
                                              placement=placement)
             ret['rs'] = rs
         except EC2ResponseError as e:
@@ -226,6 +232,7 @@ class CloudManLauncher(object):
                  ('9600', '9700'),  # HTCondor
                  ('30000', '30100'))  # FTP transfer
         progress = {'name': None,
+                    'sg_id': None,
                     'error': None,
                     'ports': ports}
         cmsg = None
@@ -253,13 +260,14 @@ class CloudManLauncher(object):
                 cmsg = self.ec2_conn.create_security_group(sg_name, 'A security '
                                                            'group for CloudMan')
             except EC2ResponseError as e:
-                err_msg = "Problem creating security group '{0}': {1} (code {2}; " \
+                err_msg = "Problem creaInvalid value 'null' for protocol. VPC security group rules must specify protocols explicitlyting security group '{0}': {1} (code {2}; " \
                           "status {3})" \
                           .format(sg_name, e.message, e.error_code, e.status)
                 bioblend.log.exception(err_msg)
                 progress['error'] = err_msg
         if cmsg:
             progress['name'] = cmsg.name
+            progress['sg_id'] = cmsg.id
             # Add appropriate authorization rules
             # If these rules already exist, nothing will be changed in the SG
             for port in ports:
@@ -297,7 +305,7 @@ class CloudManLauncher(object):
                     break
             if not g_rule_exists:
                 try:
-                    cmsg.authorize(src_group=cmsg)
+                    cmsg.authorize(src_group=cmsg,ip_protocol='tcp', from_port=0, to_port=65535)
                 except EC2ResponseError as e:
                     err_msg = "A problem with security group authorization: {0} " \
                               "(code {1}; status {2})" \


### PR DESCRIPTION
This pull request fixes two issues with boto.
* Fixes an [issue](https://github.com/galaxyproject/cloudlaunch/issues/47) with inter-node communication permissions. It seems that boto's authorize method still requires the ip_protocol, source port (0) and destination port (65535) along with the src_group parameter.
* Boto has an [issue](https://github.com/boto/boto/issues/350) with specifying a subnet and a groupName simultaneously. The solution described by this thread seems to be specifying the subnet_id's instead of the subnet name.

Let me know what you want to see here.



2. When I pass a subnet_id to boto's ```run_instances``` method, I get the following error. This seems to be a incompletely addressed idiosyncracy of the boto library and how it prefers for subnets to be specified. See this [stackoverflow post](http://stackoverflow.com/questions/23037291/python-boto-how-do-you-specify-a-subnet-id-and-a-security-group) and this [github issue](https://github.com/boto/boto/issues/350) related to the run_instances call with a subnet_id. It seems that boto prefers subnet ids over subnet names in this method. 

```
[2015-10-26 10:10:34,542: DEBUG/MainProcess] <?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidParameterCombination</Code><Message>The parameter groupName cannot be used with the parameter subnet</Message></Error></Errors><RequestID>e72077dd-f31d-4c94-b0ac-970f6c41fe56</RequestID></Response>
[2015-10-26 10:10:34,542: ERROR/MainProcess] 400 Bad Request
[2015-10-26 10:10:34,542: ERROR/MainProcess] <?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidParameterCombination</Code><Message>The parameter groupName cannot be used with the parameter subnet</Message></Error></Errors><RequestID>e72077dd-f31d-4c94-b0ac-970f6c41fe56</RequestID></Response>
[2015-10-26 10:10:34,543: ERROR/MainProcess] Problem launching an instance: The parameter groupName cannot be used with the parameter subnet (code InvalidParameterCombination; status 400)
Traceback (most recent call last):
  File "/home/ralstonm/Projects/bioblend/bioblend/cloudman/launch.py", line 177, in launch
    placement=placement)
  File "/home/ralstonm/.pyenv/versions/cloudlaunch/lib/python2.7/site-packages/boto/ec2/connection.py", line 973, in run_instances
    verb='POST')
  File "/home/ralstonm/.pyenv/versions/cloudlaunch/lib/python2.7/site-packages/boto/connection.py", line 1208, in get_object
    raise self.ResponseError(response.status, response.reason, body)
EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidParameterCombination</Code><Message>The parameter groupName cannot be used with the parameter subnet</Message></Error></Errors><RequestID>e72077dd-f31d-4c94-b0ac-970f6c41fe56</RequestID></Response>