### PR TITLE
Implement client for a modern workflow API.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_script:
   # Create a PostgreSQL database for Galaxy. The default SQLite3 database makes test fail randomly because of "database locked" error.
   - createdb -U postgres galaxy-travis
   - if [ -f universe_wsgi.ini.sample ]; then GALAXY_CONFIG_FILE=universe_wsgi.ini; else GALAXY_CONFIG_FILE=config/galaxy.ini; fi
+  - if [ -f universe_wsgi.ini.sample ]; then GALAXY_CONFIG_DIR=.; else GALAXY_CONFIG_DIR=config; fi
   # Change Galaxy configuration to use the newly created PostgreSQL database
   - sed -e 's|^#database_connection.*|database_connection = postgresql://postgres:@localhost/galaxy-travis|' $GALAXY_CONFIG_FILE.sample > $GALAXY_CONFIG_FILE
   # Setup Galaxy master API key and admin user
@@ -43,7 +44,7 @@ before_script:
   # Change Galaxy configuration needed by some library tests
   - sed -i -e 's/^#allow_library_path_paste.*/allow_library_path_paste = True/' $GALAXY_CONFIG_FILE
   - sed -i -e 's/^#enable_beta_workflow_modules.*/enable_beta_workflow_modules = True/' $GALAXY_CONFIG_FILE
-  - if [ -f test/functional/tools/samples_tool_conf.xml ]; then sed -i -e 's/^#tool_config_file.*/tool_config_file = config\/tool_conf.xml.sample,config\/shed_tool_conf.xml.sample,test\/functional\/tools\/samples_tool_conf.xml/' $GALAXY_CONFIG_FILE; fi
+  - if [ -f test/functional/tools/samples_tool_conf.xml ]; then sed -i -e "s/^#tool_config_file.*/tool_config_file = $GALAXY_CONFIG_DIR\/tool_conf.xml.sample,$GALAXY_CONFIG_DIR\/shed_tool_conf.xml.sample,test\/functional\/tools\/samples_tool_conf.xml/" $GALAXY_CONFIG_FILE; fi
   # Start Galaxy and wait for successful server start
   - GALAXY_RUN_ALL=1 ../run_galaxy.sh --daemon --wait
   # Use the master API key to create the admin user and get its API key

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
   # Change Galaxy configuration needed by some library tests
   - sed -i -e 's/^#allow_library_path_paste.*/allow_library_path_paste = True/' $GALAXY_CONFIG_FILE
   - sed -i -e 's/^#enable_beta_workflow_modules.*/enable_beta_workflow_modules = True/' $GALAXY_CONFIG_FILE
-  - sed -i -e 's/^#tool_config_file.*/tool_config_file = config\/tool_conf.xml.sample,config\/shed_tool_conf.xml.sample,test\/functional\/tools\/samples_tool_conf.xml/' $GALAXY_CONFIG_FILE
+  - if [ -f test/functional/tools/samples_tool_conf.xml ]; then sed -i -e 's/^#tool_config_file.*/tool_config_file = config\/tool_conf.xml.sample,config\/shed_tool_conf.xml.sample,test\/functional\/tools\/samples_tool_conf.xml/' $GALAXY_CONFIG_FILE; fi
   # Start Galaxy and wait for successful server start
   - GALAXY_RUN_ALL=1 ../run_galaxy.sh --daemon --wait
   # Use the master API key to create the admin user and get its API key

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_script:
   # Change Galaxy configuration needed by some library tests
   - sed -i -e 's/^#allow_library_path_paste.*/allow_library_path_paste = True/' $GALAXY_CONFIG_FILE
   - sed -i -e 's/^#enable_beta_workflow_modules.*/enable_beta_workflow_modules = True/' $GALAXY_CONFIG_FILE
+  - sed -i -e 's/^#tool_config_file.*/tool_config_file = config\/tool_conf.xml.sample,config\/shed_tool_conf.xml.sample,test\/functional\/tools\/samples_tool_conf.xml/' $GALAXY_CONFIG_FILE
   # Start Galaxy and wait for successful server start
   - GALAXY_RUN_ALL=1 ../run_galaxy.sh --daemon --wait
   # Use the master API key to create the admin user and get its API key

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_script:
   - sed -i -e 's/^#allow_user_dataset_purge.*/allow_user_dataset_purge = True/' $GALAXY_CONFIG_FILE
   # Change Galaxy configuration needed by some library tests
   - sed -i -e 's/^#allow_library_path_paste.*/allow_library_path_paste = True/' $GALAXY_CONFIG_FILE
+  - sed -i -e 's/^#enable_beta_workflow_modules.*/enable_beta_workflow_modules = True/' $GALAXY_CONFIG_FILE
   # Start Galaxy and wait for successful server start
   - GALAXY_RUN_ALL=1 ../run_galaxy.sh --daemon --wait
   # Use the master API key to create the admin user and get its API key

--- a/bioblend/galaxy/client.py
+++ b/bioblend/galaxy/client.py
@@ -183,7 +183,7 @@ class Client(object):
             url = self.gi._make_url(self, module_id=id)
         return self.gi.make_put_request(url, payload=payload, params=params)
 
-    def _delete(self, payload, id=None, deleted=False, contents=None, url=None):
+    def _delete(self, payload=None, id=None, deleted=False, contents=None, url=None):
         """
         Do a generic DELETE request, composing the url from the contents of the
         arguments. Alternatively, an explicit ``url`` can be provided to use
@@ -193,7 +193,8 @@ class Client(object):
         if not url:
             url = self.gi._make_url(self, module_id=id, deleted=deleted,
                                     contents=contents)
-        payload = json.dumps(payload)
+        if payload is not None:
+            payload = json.dumps(payload)
         r = self.gi.make_delete_request(url, payload=payload)
         if r.status_code == 200:
             return r.json()

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -414,7 +414,7 @@ class WorkflowClient(Client):
     def show_invocation(self, workflow_id, invocation_id):
         """ Get a workflow invocation object representing the scheduling of
         a workflow. This object may be sparse at first (missing inputs and
-        and invocation steps) and will become more populated as the workflow
+        invocation steps) and will become more populated as the workflow
         is actually scheduled.
 
         :type workflow_id: str

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -100,7 +100,7 @@ class WorkflowClient(Client):
         payload['workflow'] = workflow_json
 
         url = self.gi._make_url(self)
-        url = '/'.join([url, "upload"])
+        url = _join(url, "upload")
         return Client._post(self, url=url, payload=payload)
 
     def import_workflow_from_local_path(self, file_local_path):
@@ -138,7 +138,7 @@ class WorkflowClient(Client):
         payload = {}
         payload['workflow_id'] = workflow_id
         url = self.gi._make_url(self)
-        url = '/'.join([url, 'import'])
+        url = _join(url, 'import')
         return Client._post(self, url=url, payload=payload)
 
     def export_workflow_json(self, workflow_id):
@@ -152,8 +152,7 @@ class WorkflowClient(Client):
         :return: Dict representing the workflow requested
         """
         url = self.gi._make_url(self)
-        url = '/'.join([url, "download"])
-        url = '/'.join([url, workflow_id])
+        url = _join(url, "download", workflow_id)
         return Client._get(self, url=url)
 
     def export_workflow_to_local_path(self, workflow_id, file_local_path, use_default_filename=True):
@@ -186,7 +185,8 @@ class WorkflowClient(Client):
                      history_id=None, history_name=None,
                      import_inputs_to_history=False, replacement_params=None):
         """
-        Run the workflow identified by ``workflow_id``
+        Run the workflow identified by ``workflow_id``. This method is deprecated
+        please use ``invoke_workflow`` instead.
 
         :type workflow_id: str
         :param workflow_id: Encoded workflow ID
@@ -245,6 +245,13 @@ class WorkflowClient(Client):
 
         see also `this email thread
         <http://lists.bx.psu.edu/pipermail/galaxy-dev/2011-September/006875.html>`_.
+
+        .. warning::
+            This method is deprecated, please use ``invoke_workflow`` instead.
+            ``run_workflow`` will wait for the whole workflow to be scheduled
+            before returning and will not scale to large workflows as a result.
+            ``invoke_workflow`` also features improved default behavior for
+            dataset input handling.
         """
         payload = {}
         payload['workflow_id'] = workflow_id
@@ -265,6 +272,285 @@ class WorkflowClient(Client):
             payload['no_add_to_history'] = True
         return Client._post(self, payload)
 
+    def invoke_workflow(self, workflow_id, inputs=None, params=None,
+                        history_id=None, history_name=None,
+                        import_inputs_to_history=False, replacement_params=None,
+                        allow_tool_state_corrections=None):
+        """
+        Invoke the workflow identified by ``workflow_id``. This will
+        cause a workflow to be scheduled and return an object describing
+        the workflow invocation.
+
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
+
+        :type inputs: dict
+        :param inputs: A mapping of workflow inputs to datasets and dataset collections.
+                       The datasets source can be a LibraryDatasetDatasetAssociation (``ldda``),
+                       LibraryDataset (``ld``), HistoryDatasetAssociation (``hda``), or
+                       HistoryDatasetCollectionAssociation (``hdca``).
+
+                       The map must be in the following format:
+                       ``{'<input_index>': {'id': <encoded dataset ID>, 'src': '[ldda, ld, hda, hdca]'}}``
+                       (e.g. ``{'2': {'id': '29beef4fadeed09f', 'src': 'hda'}}``)
+
+                       This map may also be indexed by the UUIDs of the workflow steps,
+                       as indicated by the ``uuid`` property of steps returned from the
+                       Galaxy API.
+
+        :type params: str or dict
+        :param params: A mapping of tool parameters that are non-datasets parameters. The map must be in the
+                         following format:
+                         ``{'blastn': {'param': 'evalue', 'value': '1e-06'}}``
+
+        :type history_id: str
+        :param history_id: The encoded history ID where to store the workflow
+          output. Alternatively, ``history_name`` may be specified to create a
+          new history.
+
+        :type history_name: str
+        :param history_name: Create a new history with the given name to store
+          the workflow output. If both ``history_id`` and ``history_name`` are
+          provided, ``history_name`` is ignored. If neither is specified, a new
+          'Unnamed history' is created.
+
+        :type import_inputs_to_history: bool
+        :param import_inputs_to_history: If ``True``, used workflow inputs will be imported
+                                         into the history. If ``False``, only workflow outputs
+                                         will be visible in the given history.
+
+        :type allow_tool_state_corrections: bool
+        :param allow_tool_state_corrections: If True, allow Galaxy to fill in missing tool state
+                                             when running workflows. This may be useful
+                                             for workflows using tools that have changed
+                                             over time or for workflows built outside of
+                                             Galaxy with only a subset of inputs defined.
+
+        :type replacement_params: dict
+        :param replacement_params: pattern-based replacements for post-job actions (see below)
+
+        :rtype: dict
+        :return: A dict containing the workflow invocation describing the scheduling
+           of the workflow. For example::
+
+                  {u'inputs': {u'0': {u'src': u'hda', u'id': u'a7db2fac67043c7e', u'uuid': u'7932ffe0-2340-4952-8857-dbaa50f1f46a'}},
+                   u'update_time': u'2015-10-31T22:00:26',
+                   u'uuid': u'c8aa2b1c-801a-11e5-a9e5-8ca98228593c',
+                   u'history_id': u'2f94e8ae9edff68a',
+                   u'workflow_id': u'03501d7626bd192f',
+                   u'state': u'ready',
+                   u'steps': [{u'workflow_step_uuid': u'b81250fd-3278-4e6a-b269-56a1f01ef485',
+                               u'update_time': u'2015-10-31T22:00:26',
+                               u'job_id': None,
+                               u'state': None,
+                               u'workflow_step_label': None,
+                               u'order_index': 0,
+                               u'action': None,
+                               u'model_class': u'WorkflowInvocationStep',
+                               u'workflow_step_id': u'cbbbf59e8f08c98c',
+                               u'id': u'd413a19dec13d11e'},
+                              {u'workflow_step_uuid': u'e62440b8-e911-408b-b124-e05435d3125e',
+                               u'update_time': u'2015-10-31T22:00:26',
+                               u'job_id': u'e89067bb68bee7a0',
+                               u'state': u'new',
+                               u'workflow_step_label':None,
+                               u'order_index': 1,
+                               u'action': None,
+                               u'model_class': u'WorkflowInvocationStep',
+                               u'workflow_step_id': u'964b37715ec9bd22',
+                               u'id': u'2f94e8ae9edff68a'},
+                             ],
+                   u'model_class': u'WorkflowInvocation',
+                   u'id': u'df7a1f0c02a5b08e'
+                  }
+
+        The ``replacement_params`` dict should map parameter names in
+        post-job actions (PJAs) to their runtime values. For
+        instance, if the final step has a PJA like the following::
+
+          {u'RenameDatasetActionout_file1': {
+           u'action_arguments': {u'newname': u'${output}'},
+           u'action_type': u'RenameDatasetAction',
+           u'output_name': u'out_file1'}}
+
+        then the following renames the output dataset to 'foo'::
+
+          replacement_params = {'output': 'foo'}
+
+        see also `this email thread
+        <http://lists.bx.psu.edu/pipermail/galaxy-dev/2011-September/006875.html>`_.
+
+        .. warning::
+            Historically, the ``run_workflow`` method consumed a ``dataset_map``
+            data structure that was indexed by unencoded workflow step IDs. These
+            IDs would not be stable across Galaxy instances. The new ``inputs``
+            property is instead indexed by either the ``order_index`` property which
+            is stable across workflow imports or the step UUID which is also stable.
+
+        """
+        payload = {}
+        payload['workflow_id'] = workflow_id
+        if inputs:
+            payload['inputs'] = inputs
+
+        if params:
+            payload['parameters'] = params
+
+        if replacement_params:
+            payload['replacement_params'] = replacement_params
+
+        if history_id:
+            payload['history'] = 'hist_id={0}'.format(history_id)
+        elif history_name:
+            payload['history'] = history_name
+        if import_inputs_to_history is False:
+            payload['no_add_to_history'] = True
+        if allow_tool_state_corrections is not None:
+            payload['allow_tool_state_corrections'] = allow_tool_state_corrections
+        url = self.gi._make_url(self)
+        url = _join(url, workflow_id, "invocations")
+        return Client._post(self, payload, url=url)
+
+    def show_invocation(self, workflow_id, invocation_id):
+        """ Get a workflow invocation object representing the scheduling of
+        a workflow. This object may be sparse at first (missing inputs and
+        and invocation steps) and will become more populated as the workflow
+        is actually scheduled.
+
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
+
+        :type invocation_id: str
+        :param invocation_id: Encoded workflow invocation ID
+
+        :rtype: dict
+        :return: The workflow invocation.
+           For example::
+
+                  {u'inputs': {u'0': {u'src': u'hda', u'id': u'a7db2fac67043c7e', u'uuid': u'7932ffe0-2340-4952-8857-dbaa50f1f46a'}},
+                   u'update_time': u'2015-10-31T22:00:26',
+                   u'uuid': u'c8aa2b1c-801a-11e5-a9e5-8ca98228593c',
+                   u'history_id': u'2f94e8ae9edff68a',
+                   u'workflow_id': u'03501d7626bd192f',
+                   u'state': u'ready',
+                   u'steps': [{u'workflow_step_uuid': u'b81250fd-3278-4e6a-b269-56a1f01ef485',
+                               u'update_time': u'2015-10-31T22:00:26',
+                               u'job_id': None,
+                               u'state': None,
+                               u'workflow_step_label': None,
+                               u'order_index': 0,
+                               u'action': None,
+                               u'model_class': u'WorkflowInvocationStep',
+                               u'workflow_step_id': u'cbbbf59e8f08c98c',
+                               u'id': u'd413a19dec13d11e'},
+                              {u'workflow_step_uuid': u'e62440b8-e911-408b-b124-e05435d3125e',
+                               u'update_time': u'2015-10-31T22:00:26',
+                               u'job_id': u'e89067bb68bee7a0',
+                               u'state': u'new',
+                               u'workflow_step_label':None,
+                               u'order_index': 1,
+                               u'action': None,
+                               u'model_class': u'WorkflowInvocationStep',
+                               u'workflow_step_id': u'964b37715ec9bd22',
+                               u'id': u'2f94e8ae9edff68a'},
+                             ],
+                   u'model_class': u'WorkflowInvocation',
+                   u'id': u'df7a1f0c02a5b08e'
+                  }
+        """
+        url = self._invocation_url(workflow_id, invocation_id)
+        return Client._get(self, url=url)
+
+    def get_invocations(self, workflow_id):
+        """ Get a list containing all the workflow invocations corresponding
+        to the specified workflow.
+
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
+
+        :rtype: list
+        :return: A list of workflow invocations.
+           For example::
+
+                   [{u'update_time': u'2015-10-31T22:00:22',
+                     u'uuid': u'c8aa2b1c-801a-11e5-a9e5-8ca98228593c',
+                     u'history_id': u'2f94e8ae9edff68a',
+                     u'workflow_id': u'03501d7626bd192f',
+                     u'state': u'new',
+                     u'model_class': u'WorkflowInvocation',
+                     u'id': u'df7a1f0c02a5b08e'}
+                   ]
+        """
+        url = self._invocations_url(workflow_id)
+        return Client._get(self, url=url)
+
+    def cancel_invocation(self, workflow_id, invocation_id):
+        """ Cancel the scheduling of a workflow.
+
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
+
+        :type invocation_id: str
+        :param invocation_id: Encoded workflow invocation ID
+        """
+        url = self._invocation_url(workflow_id, invocation_id)
+        return Client._delete(self, url=url)
+
+    def show_invocation_step(self, workflow_id, invocation_id, step_id):
+        """ See the details of a particular workflow invocation step.
+
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
+
+        :type invocation_id: str
+        :param invocation_id: Encoded workflow invocation ID
+
+        :type step_id: str
+        :param step_id: Encoded workflow invocation step ID
+
+        :rtype: dict
+        :return: The workflow invocation step.
+           For example::
+
+                   {u'workflow_step_uuid': u'4060554c-1dd5-4287-9040-8b4f281cf9dc',
+                    u'update_time': u'2015-10-31T22:11:14',
+                    u'job_id': None,
+                    u'state': None,
+                    u'workflow_step_label': None,
+                    u'order_index': 2,
+                    u'action': None,
+                    u'model_class': u'WorkflowInvocationStep',
+                    u'workflow_step_id': u'52e496b945151ee8',
+                    u'id': u'63cd3858d057a6d1'}
+
+        """
+        url = self._invocation_step_url(workflow_id, invocation_id, step_id)
+        return Client._get(self, url=url)
+
+    def run_invocation_step_action(self, workflow_id, invocation_id, step_id, action):
+        """ Execute an action for an active workflow invocation step. The
+        nature of this action and what is expected will vary based on the
+        the type of workflow step (the only currently valid action is True/False
+        for pause steps).
+
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
+
+        :type invocation_id: str
+        :param invocation_id: Encoded workflow invocation ID
+
+        :type step_id: str
+        :param step_id: Encoded workflow invocation step ID
+
+        :type action: object
+        :param action: Action to use when updating state, semantics depends on
+           step type.
+
+        """
+        url = self._invocation_step_url(workflow_id, invocation_id, step_id)
+        payload = {"action": action}
+        return Client._put(self, payload, url=url)
+
     def delete_workflow(self, workflow_id):
         """
         Delete a workflow identified by `workflow_id`.
@@ -278,3 +564,24 @@ class WorkflowClient(Client):
         """
         payload = {}
         return Client._delete(self, payload, id=workflow_id)
+
+    def _invocation_step_url(self, workflow_id, invocation_id, step_id):
+        return _join(self._invocation_url(workflow_id, invocation_id), "steps", step_id)
+
+    def _invocation_url(self, workflow_id, invocation_id):
+        return _join(self._invocations_url(workflow_id), invocation_id)
+
+    def _invocations_url(self, workflow_id):
+        return _join(self._workflow_url(workflow_id), "invocations")
+
+    def _workflow_url(self, workflow_id):
+        url = self.gi._make_url(self)
+        url = _join(url, workflow_id)
+        return url
+
+
+def _join(*args):
+    return "/".join(args)
+
+
+__all__ = ['WorkflowClient']

--- a/tests/TestGalaxyWorkflows.py
+++ b/tests/TestGalaxyWorkflows.py
@@ -68,7 +68,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         invocation = self.gi.workflows.show_invocation(workflow_id, invocation_id)
         assert invocation["state"] == "scheduled"
 
-    @test_util.skip_unless_galaxy('release_15.01')
+    @test_util.skip_unless_galaxy('release_15.03')
     @test_util.skip_unless_tool("cat1")
     @test_util.skip_unless_tool("cat")
     def test_cancelling_workflow_scheduling(self):

--- a/tests/TestGalaxyWorkflows.py
+++ b/tests/TestGalaxyWorkflows.py
@@ -20,6 +20,8 @@ def get_abspath(path):
 class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
 
     @test_util.skip_unless_galaxy('release_15.01')
+    @test_util.skip_unless_tool("cat1")
+    @test_util.skip_unless_tool("cat")
     def test_workflow_scheduling(self):
         path = get_abspath(os.path.join('data', 'test_workflow_pause.ga'))
         workflow = self.gi.workflows.import_workflow_from_local_path(path)
@@ -67,6 +69,8 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         assert invocation["state"] == "scheduled"
 
     @test_util.skip_unless_galaxy('release_15.01')
+    @test_util.skip_unless_tool("cat1")
+    @test_util.skip_unless_tool("cat")
     def test_cancelling_workflow_scheduling(self):
         path = get_abspath(os.path.join('data', 'test_workflow_pause.ga'))
         workflow = self.gi.workflows.import_workflow_from_local_path(path)

--- a/tests/TestGalaxyWorkflows.py
+++ b/tests/TestGalaxyWorkflows.py
@@ -19,7 +19,7 @@ def get_abspath(path):
 @test_util.skip_unless_galaxy()
 class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
 
-    @test_util.skip_unless_galaxy('release_15.01')
+    @test_util.skip_unless_galaxy('release_15.03')
     @test_util.skip_unless_tool("cat1")
     @test_util.skip_unless_tool("cat")
     def test_workflow_scheduling(self):

--- a/tests/TestGalaxyWorkflows.py
+++ b/tests/TestGalaxyWorkflows.py
@@ -17,6 +17,7 @@ def get_abspath(path):
 @test_util.skip_unless_galaxy()
 class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
 
+    @test_util.skip_unless_galaxy('release_15.01')
     def test_workflow_scheduling(self):
         path = get_abspath(os.path.join('data', 'test_workflow_pause.ga'))
         workflow = self.gi.workflows.import_workflow_from_local_path(path)
@@ -63,6 +64,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         invocation = self.gi.workflows.show_invocation(workflow_id, invocation_id)
         assert invocation["state"] == "scheduled"
 
+    @test_util.skip_unless_galaxy('release_15.01')
     def test_cancelling_workflow_scheduling(self):
         path = get_abspath(os.path.join('data', 'test_workflow_pause.ga'))
         workflow = self.gi.workflows.import_workflow_from_local_path(path)

--- a/tests/TestGalaxyWorkflows.py
+++ b/tests/TestGalaxyWorkflows.py
@@ -6,6 +6,8 @@ import json
 import tempfile
 import time
 import shutil
+from six.moves import range
+
 import GalaxyTestBase
 import test_util
 
@@ -41,7 +43,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
             invocation = self.gi.workflows.show_invocation(workflow_id, invocation_id)
             return dict([(s["order_index"], s) for s in invocation["steps"]])
 
-        for i in xrange(20):
+        for i in range(20):
             if 2 in invocation_steps_by_order_index():
                 break
             time.sleep(.5)
@@ -54,7 +56,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         assert self.gi.workflows.show_invocation_step(workflow_id, invocation_id, pause_step["id"])["action"] is None
         self.gi.workflows.run_invocation_step_action(workflow_id, invocation_id, pause_step["id"], action=True)
         assert self.gi.workflows.show_invocation_step(workflow_id, invocation_id, pause_step["id"])["action"] is True
-        for i in xrange(20):
+        for i in range(20):
             invocation = self.gi.workflows.show_invocation(workflow_id, invocation_id)
             if invocation["state"] == "scheduled":
                 break

--- a/tests/data/test_workflow_pause.ga
+++ b/tests/data/test_workflow_pause.ga
@@ -1,0 +1,118 @@
+{
+    "a_galaxy_workflow": "true", 
+    "annotation": "", 
+    "format-version": "0.1", 
+    "name": "test_workflow_pause", 
+    "steps": {
+        "0": {
+            "annotation": "", 
+            "id": 0, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "", 
+                    "name": "Input Dataset"
+                }
+            ], 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 199.9201512336731, 
+                "top": 251.4826512336731
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"Input Dataset\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "user_outputs": []
+        }, 
+        "1": {
+            "annotation": "", 
+            "id": 1, 
+            "input_connections": {
+                "input1": {
+                    "id": 0, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "name": "Concatenate datasets (for test workflows)", 
+            "outputs": [
+                {
+                    "name": "out_file1", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 516.7257237434387, 
+                "top": 187.28126573562622
+            }, 
+            "post_job_actions": {}, 
+            "tool_errors": null, 
+            "tool_id": "cat", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input1\": \"null\", \"queries\": \"[]\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "user_outputs": []
+        }, 
+        "2": {
+            "annotation": "", 
+            "id": 2, 
+            "input_connections": {
+                "input": {
+                    "id": 1, 
+                    "output_name": "out_file1"
+                }
+            }, 
+            "inputs": [
+                {
+                    "description": "", 
+                    "name": "Pause for Dataset Review"
+                }
+            ], 
+            "name": "Pause for dataset review", 
+            "outputs": [], 
+            "position": {
+                "left": 862.715301990509, 
+                "top": 197.28126573562622
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"Pause for Dataset Review\"}", 
+            "tool_version": null, 
+            "type": "pause", 
+            "user_outputs": []
+        }, 
+        "3": {
+            "annotation": "", 
+            "id": 3, 
+            "input_connections": {
+                "input1": {
+                    "id": 2, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "name": "Concatenate datasets (for test workflows)", 
+            "outputs": [
+                {
+                    "name": "out_file1", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 1181.9722595214844, 
+                "top": 181.52084350585938
+            }, 
+            "post_job_actions": {}, 
+            "tool_errors": null, 
+            "tool_id": "cat1", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input1\": \"null\", \"queries\": \"[]\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "user_outputs": []
+        }
+    }, 
+    "uuid": "9058956e-76b6-4909-bab3-c12b2cc394c7"
+}


### PR DESCRIPTION
 - Deprecate ``run_workflow`` in favor in ``invoke_workflow`` which runs workflows in the background and has superior input handling.
 - Add set of methods for interfacing with invocations via the API (get, show, cancel).
 - Add methods for interfacing with workflow invocation steps (show, run action).
 - Add tests that exercises all of this with a workflow that contains a pause step.

Closes #153.

Meta Commentary: Giving an API tutorial at a workshop at the festival of genomics Tuesday so if this can be reviewed, merged, and in a released bioblend by midday Monday I'd totally buy people involved a beer or three :cold_sweat:.