### PR TITLE
add global tempfile permissions

### DIFF
--- a/tests/TestGalaxyLibraries.py
+++ b/tests/TestGalaxyLibraries.py
@@ -57,6 +57,7 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
     def test_upload_from_galaxy_filesystem(self):
         bnames = ['f%d.txt' % i for i in range(2)]
         tempdir = tempfile.mkdtemp(prefix='bioblend_test_')
+        os.chmod(tempdir, 0o777)
         try:
             fnames = [os.path.join(tempdir, _) for _ in bnames]
             for fn in fnames:

--- a/tests/TestGalaxyObjects.py
+++ b/tests/TestGalaxyObjects.py
@@ -87,6 +87,7 @@ def is_reachable(url):
 
 def upload_from_fs(lib, bnames, **kwargs):
     tempdir = tempfile.mkdtemp(prefix='bioblend_test_')
+    os.chmod(tempdir, 0o777)
     try:
         fnames = [os.path.join(tempdir, _) for _ in bnames]
         for fn in fnames:


### PR DESCRIPTION
To use bioblend for [automatic testing](https://github.com/bgruening/docker-galaxy-stable/blob/travis_testing/.travis.yml) of our Galaxy Docker containers we need to share the bioblend test data with the Docker container. To make this possible we need to relax the permissions a little bit.

@afgane this fixes all failing tests for me.

