### PR TITLE
Add bioblend.toolshed.categories.ToolShedCategoryClient .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,8 +100,8 @@
 
 * Added ``copy_from_dataset()`` method to ``LibraryClient``.
 
-* Added ``create_repository()`` method to ``ToolShedClient`` (thanks to Eric
-  Rasche).
+* Added ``create_repository()`` method to ``ToolShedRepositoryClient`` (thanks
+  to Eric Rasche).
 
 * Fixed ``DatasetClient.download_dataset()`` for certain proxied Galaxy
   deployments.

--- a/bioblend/toolshed/__init__.py
+++ b/bioblend/toolshed/__init__.py
@@ -1,9 +1,8 @@
 """
 A base representation of an instance of Tool Shed
 """
-from bioblend.toolshed import (repositories)
-from bioblend.toolshed import (tools)
 from bioblend.galaxyclient import GalaxyClient
+from bioblend.toolshed import categories, repositories, tools
 
 
 class ToolShedInstance(GalaxyClient):
@@ -35,5 +34,6 @@ class ToolShedInstance(GalaxyClient):
                     obtained from the user preferences.
         """
         super(ToolShedInstance, self).__init__(url, key, email, password)
-        self.repositories = repositories.ToolShedClient(self)
-        self.tools = tools.ToolShedClient(self)
+        self.categories = categories.ToolShedCategoryClient(self)
+        self.repositories = repositories.ToolShedRepositoryClient(self)
+        self.tools = tools.ToolShedToolClient(self)

--- a/bioblend/toolshed/categories/__init__.py
+++ b/bioblend/toolshed/categories/__init__.py
@@ -1,0 +1,47 @@
+"""
+Interaction with a Tool Shed instance categories
+"""
+from bioblend.galaxy.client import Client
+
+
+class ToolShedCategoryClient(Client):
+
+    def __init__(self, toolshed_instance):
+        self.module = 'categories'
+        super(ToolShedCategoryClient, self).__init__(toolshed_instance)
+
+    def get_categories(self, deleted=False):
+        """
+        Returns a list of dictionaries that contain descriptions of the
+        repository categories found on the given Tool Shed instance.
+
+        :type deleted: bool
+        :param deleted: whether to show deleted categories
+
+        :rtype: list
+        :return: A list of dictionaries containing information about
+          repository categories present in the Tool Shed.
+          For example::
+
+            [{u'deleted': False,
+              u'description': u'Tools for manipulating data',
+              u'id': u'175812cd7caaf439',
+              u'model_class': u'Category',
+              u'name': u'Text Manipulation',
+              u'url': u'/api/categories/175812cd7caaf439'}]
+
+        .. versionadded:: 0.5.2
+        """
+        return Client._get(self, deleted=deleted)
+
+    def show_category(self, category_id):
+        """
+        Get details of a given category.
+
+        :type category_id: str
+        :param category_id: Encoded category ID
+
+        :rtype: dict
+        :return: details of the given category
+        """
+        return Client._get(self, id=category_id)

--- a/bioblend/toolshed/repositories/__init__.py
+++ b/bioblend/toolshed/repositories/__init__.py
@@ -1,17 +1,15 @@
 """
 Interaction with a Tool Shed instance repositories
 """
-from six.moves.urllib.parse import urljoin
-
 from bioblend.galaxy.client import Client
 from bioblend.util import attach_file
 
 
-class ToolShedClient(Client):
+class ToolShedRepositoryClient(Client):
 
     def __init__(self, toolshed_instance):
         self.module = 'repositories'
-        super(ToolShedClient, self).__init__(toolshed_instance)
+        super(ToolShedRepositoryClient, self).__init__(toolshed_instance)
 
     def get_repositories(self):
         """
@@ -362,30 +360,7 @@ class ToolShedClient(Client):
         # Not using '_make_url' or '_get' to create url since the module id used
         # to create url is not the same as needed for this method
         # since metadata_id has to be defined, easy to create the url here
-        url = self.gi.url + '/repository_revisions/' + metadata_id
-
-        return Client._get(self, url=url)
-
-    def get_categories(self):
-        """
-        Returns a list of dictionaries that contain descriptions of the
-        repository categories found on the given Tool Shed instance.
-
-        :rtype: list
-        :return: A list of dictionaries containing information about
-                 repository categories present in the Tool Shed.
-                 For example::
-
-                    [{u'deleted': False,
-                      u'description': u'Tools for manipulating data',
-                      u'id': u'175812cd7caaf439',
-                      u'model_class': u'Category',
-                      u'name': u'Text Manipulation',
-                      u'url': u'/api/categories/175812cd7caaf439'}]
-
-        .. versionadded:: 0.5.2
-        """
-        url = urljoin(self.url, 'categories')
+        url = '/'.join([self.gi.url, 'repository_revisions', metadata_id])
         return Client._get(self, url=url)
 
     def update_repository(self, id, tar_ball_path, commit_message=None):

--- a/bioblend/toolshed/tools/__init__.py
+++ b/bioblend/toolshed/tools/__init__.py
@@ -4,11 +4,11 @@ Interaction with a Tool Shed instance tools
 from bioblend.galaxy.client import Client
 
 
-class ToolShedClient(Client):
+class ToolShedToolClient(Client):
 
     def __init__(self, toolshed_instance):
         self.module = 'tools'
-        super(ToolShedClient, self).__init__(toolshed_instance)
+        super(ToolShedToolClient, self).__init__(toolshed_instance)
 
     def search_tools(self, q, page=1, page_size=10):
         """

--- a/docs/api_docs/toolshed/all.rst
+++ b/docs/api_docs/toolshed/all.rst
@@ -10,6 +10,11 @@ ToolShedInstance
     .. automethod:: bioblend.toolshed.ToolShedInstance.__init__
 
 
+Categories
+----------
+
+.. automodule:: bioblend.toolshed.categories
+
 Repositories
 ------------
 


### PR DESCRIPTION
Rename `bioblend.toolshed.repositories.ToolShedClient` class to
`bioblend.toolshed.repositories.ToolShedRepositoryClient` .
Rename `bioblend.toolshed.tools.ToolShedClient` class to
`bioblend.toolshed.tools.ToolShedToolClient` .

Ping @afgane: you added the `bioblend.toolshed.repositories.get_categories()` method in de600e1635ac70252d2b921ee6c24f27760ae0cb, but I think it never worked.