### PR TITLE
Modify update methods of HistoryClient to return the details instead of the status code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   ``update_history()`` methods of ``HistoryClient`` to return the details
   instead of the status code.
 
+* BioBlend.objects: added ``update()`` method to ``HistoryDatasetAssociation``.
+
 * Removed deprecated method ``create_user()`` of ``UserClient``.
 
 ### BioBlend v0.7.0 - November 2, 2015

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+### BioBlend v0.8.0 - Unreleased
+
 * Added ``delete_user()`` method to ``UserClient``.
+
+* Modified ``update_dataset()``, ``update_dataset_collection()`` and
+  ``update_history()`` methods of ``HistoryClient`` to return the details
+  instead of the status code.
 
 * Removed deprecated method ``create_user()`` of ``UserClient``.
 

--- a/bioblend/__init__.py
+++ b/bioblend/__init__.py
@@ -92,9 +92,10 @@ class ConnectionError(Exception):
     proxy server getting in the way of the request etc.
     @see: body attribute to see the content of the http response
     """
-    def __init__(self, message, body=None):
+    def __init__(self, message, body=None, status_code=None):
         super(ConnectionError, self).__init__(message)
         self.body = body
+        self.status_code = status_code
 
     def __str__(self):
         return "{0}: {1}".format(self.args[0], self.body)

--- a/bioblend/galaxy/groups/__init__.py
+++ b/bioblend/galaxy/groups/__init__.py
@@ -96,16 +96,13 @@ class GroupsClient(Client):
         :type role_ids: list
         :param role_ids: New list of encoded role IDs for the group. It will
           substitute the previous list of roles (with [] if not specified)
-
-        :rtype: int
-        :return: status code
         """
         payload = {
             'name': group_name,
             'user_ids': user_ids,
             'role_ids': role_ids
         }
-        return Client._put(self, payload, id=group_id).status_code
+        return Client._put(self, payload, id=group_id)
 
     def get_group_users(self, group_id):
         """
@@ -147,7 +144,7 @@ class GroupsClient(Client):
         :return: Added group user's info
         """
         url = '/'.join([self.gi._make_url(self, group_id), 'users', user_id])
-        return Client._put(self, dict(), url=url).json()
+        return Client._put(self, dict(), url=url)
 
     def add_group_role(self, group_id, role_id):
         """
@@ -163,7 +160,7 @@ class GroupsClient(Client):
         :return: Added group role's info
         """
         url = '/'.join([self.gi._make_url(self, group_id), 'roles', role_id])
-        return Client._put(self, {}, url=url).json()
+        return Client._put(self, {}, url=url)
 
     def delete_group_user(self, group_id, user_id):
         """

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -625,9 +625,39 @@ class HistoryDatasetAssociation(Dataset):
             self.gi.gi.histories, module_id=self.container.id, contents=True)
         return "%s/%s/display" % (base_url, self.id)
 
+    def update(self, **kwds):
+        """
+        Update this history dataset metadata. Some of the attributes that can be
+        modified are documented below.
+
+        :type name: str
+        :param name: Replace history dataset name with the given string
+
+        :type genome_build: str
+        :param genome_build: Replace history dataset genome build (dbkey)
+
+        :type annotation: str
+        :param annotation: Replace history dataset annotation with given string
+
+        :type deleted: bool
+        :param deleted: Mark or unmark history dataset as deleted
+
+        :type visible: bool
+        :param visible: Mark or unmark history dataset as visible
+        """
+        res = self.gi.gi.histories.update_dataset(self.container.id, self.id, **kwds)
+        # Refresh also the history because the dataset may have been (un)deleted
+        self.container.refresh()
+        if 'id' in res:
+            self.__init__(res, self.container, gi=self.gi)
+        else:
+            # for Galaxy < release_15.03 res contains only the updated fields
+            self.refresh()
+        return self
+
     def delete(self):
         """
-        Delete this dataset.
+        Delete this history dataset.
         """
         self.gi.gi.histories.delete_dataset(self.container.id, self.id)
         self.container.refresh()

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -8,7 +8,6 @@ import abc
 import collections
 import json
 
-from six.moves import http_client
 import six
 
 import bioblend
@@ -904,10 +903,8 @@ class History(DatasetContainer):
         # TODO: wouldn't it be better if name and annotation were attributes?
         # TODO: do we need to ensure the attributes of `self` are the same as
         # the ones returned by the call to `update_history` below?
-        res = self.gi.gi.histories.update_history(
-            self.id, name=name, annotation=annotation, **kwds)
-        if res != http_client.OK:
-            raise RuntimeError('failed to update history')
+        self.gi.gi.histories.update_history(self.id, name=name,
+                                            annotation=annotation, **kwds)
         self.refresh()
         return self
 

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -128,10 +128,10 @@ class GalaxyClient(object):
                 return r.json()
             except Exception as e:
                 raise ConnectionError("Request was successful, but cannot decode the response content: %s" %
-                                      e, body=r.content)
+                                      e, body=r.content, status_code=r.status_code)
         # @see self.body for HTTP response body
-        raise ConnectionError("Unexpected HTTP status code: %s" %
-                              r.status_code, body=r.text)
+        raise ConnectionError("Unexpected HTTP status code: %s" % r.status_code,
+                              body=r.text, status_code=r.status_code)
 
     def make_delete_request(self, url, payload=None, params=None):
         """
@@ -167,7 +167,15 @@ class GalaxyClient(object):
 
         payload = json.dumps(payload)
         r = requests.put(url, verify=self.verify, data=payload, params=params)
-        return r
+        if r.status_code == 200:
+            try:
+                return r.json()
+            except Exception as e:
+                raise ConnectionError("Request was successful, but cannot decode the response content: %s" %
+                                      e, body=r.content, status_code=r.status_code)
+        # @see self.body for HTTP response body
+        raise ConnectionError("Unexpected HTTP status code: %s" % r.status_code,
+                              body=r.text, status_code=r.status_code)
 
     @property
     def key(self):

--- a/tests/TestGalaxyHistories.py
+++ b/tests/TestGalaxyHistories.py
@@ -28,8 +28,9 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
         new_name = 'buildbot - automated test renamed'
         new_annotation = 'Annotation for %s' % new_name
         new_tags = ['tag1', 'tag2']
-        self.gi.histories.update_history(self.history['id'], name=new_name, annotation=new_annotation, tags=new_tags)
-        updated_hist = self.gi.histories.show_history(self.history['id'])
+        updated_hist = self.gi.histories.update_history(self.history['id'], name=new_name, annotation=new_annotation, tags=new_tags)
+        if 'id' not in updated_hist:
+            updated_hist = self.gi.histories.show_history(self.history['id'])
         self.assertEqual(self.history['id'], updated_hist['id'])
         self.assertEqual(updated_hist['name'], new_name)
         self.assertEqual(updated_hist['annotation'], new_annotation)
@@ -102,9 +103,10 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
     def test_update_dataset(self):
         history_id = self.history["id"]
         dataset1_id = self._test_dataset(history_id)
-        self.gi.histories.update_dataset(history_id, dataset1_id, visible=False)
-        dataset = self.gi.histories.show_dataset(history_id, dataset1_id)
-        self.assertFalse(dataset["visible"])
+        updated_dataset = self.gi.histories.update_dataset(history_id, dataset1_id, visible=False)
+        if 'id' not in updated_dataset:
+            updated_dataset = self.gi.histories.show_dataset(history_id, dataset1_id)
+        self.assertFalse(updated_dataset["visible"])
 
     def test_upload_dataset_from_library(self):
         pass

--- a/tests/TestGalaxyObjects.py
+++ b/tests/TestGalaxyObjects.py
@@ -679,6 +679,16 @@ class TestHDAContents(GalaxyObjectsTestBase):
     def test_dataset_get_contents(self):
         self.assertEqual(six.b(FOO_DATA), self.ds.get_contents())
 
+    def test_dataset_update(self):
+        new_name = 'test_%s' % uuid.uuid4().hex
+        new_annotation = 'Annotation for %s' % new_name
+        new_genome_build = 'hg19'
+        updated_hda = self.ds.update(name=new_name, annotation=new_annotation, genome_build=new_genome_build)
+        self.assertEqual(self.ds.id, updated_hda.id)
+        self.assertEqual(self.ds.name, new_name)
+        self.assertEqual(self.ds.annotation, new_annotation)
+        self.assertEqual(self.ds.genome_build, new_genome_build)
+
     def test_dataset_delete(self):
         self.ds.delete()
         self.assertTrue(self.ds.deleted)


### PR DESCRIPTION
Also:
- modify `GalaxyClient.make_put_request()` to return the decoded response content
- added `update()` method to `HistoryDatasetAssociation`.

Asking for a review since this slightly modifies our API.