### PR TITLE
Add install_resolver_dependencies keyword to install_repository_revision

### DIFF
--- a/bioblend/galaxy/toolshed/__init__.py
+++ b/bioblend/galaxy/toolshed/__init__.py
@@ -111,7 +111,8 @@ class ToolShedClient(Client):
 
         :type install_resolver_dependencies: bool
         :param install_resolver_dependencies: Whether or not to automatically
-                                                install resolver dependencies (e.g. conda)
+                                                install resolver dependencies (e.g. conda).
+                                                This parameter is silently ignored in Galaxy ``release_2016.04`` and earlier.
 
         :type tool_panel_section_id: str
         :param tool_panel_section_id: The ID of the Galaxy tool panel section

--- a/bioblend/galaxy/toolshed/__init__.py
+++ b/bioblend/galaxy/toolshed/__init__.py
@@ -63,6 +63,7 @@ class ToolShedClient(Client):
                                     changeset_revision,
                                     install_tool_dependencies=False,
                                     install_repository_dependencies=False,
+                                    install_resolver_dependencies=False,
                                     tool_panel_section_id=None,
                                     new_tool_panel_section_label=None):
         """
@@ -71,7 +72,10 @@ class ToolShedClient(Client):
         that contains valid tools, loading them into a section of the Galaxy tool
         panel or creating a new tool panel section.
         You can choose if tool dependencies or repository dependencies should be
-        installed, use ``install_tool_dependencies`` or ``install_repository_dependencies``.
+        installed through the tool shed,
+        (use ``install_tool_dependencies`` or ``install_repository_dependencies``)
+        or through a resolver that supports installing dependencies
+        (use ``install_resolver_dependencies``).
 
         Installing the repository into an existing tool panel section requires
         the tool panel config file (e.g., tool_conf.xml, shed_tool_conf.xml, etc)
@@ -105,6 +109,10 @@ class ToolShedClient(Client):
                                                 (see http://wiki.galaxyproject.org/DefiningRepositoryDependencies
                                                 for more details)
 
+        :type install_resolver_dependencies: bool
+        :param install_resolver_dependencies: Whether or not to automatically
+                                                install resolver dependencies (e.g. conda)
+
         :type tool_panel_section_id: str
         :param tool_panel_section_id: The ID of the Galaxy tool panel section
                                       where the tool should be insterted under.
@@ -125,6 +133,7 @@ class ToolShedClient(Client):
         payload['changeset_revision'] = changeset_revision
         payload['install_tool_dependencies'] = install_tool_dependencies
         payload['install_repository_dependencies'] = install_repository_dependencies
+        payload['install_resolver_dependencies'] = install_resolver_dependencies
         if tool_panel_section_id:
             payload['tool_panel_section_id'] = tool_panel_section_id
         elif new_tool_panel_section_label:


### PR DESCRIPTION
This goes together with https://github.com/galaxyproject/galaxy/pull/2554.
On older galaxy instances install_resolver_dependencies will be silently ignored.
Is that okay or should we explicitly check the galaxy version?
ping @nsoranzo 