### PR TITLE
Fix link to cloudman

### DIFF
--- a/ABOUT.rst
+++ b/ABOUT.rst
@@ -55,6 +55,6 @@ things like this:
     with an instance of Galaxy running on your laptop.
 
 .. References/hyperlinks used above
-.. _CloudMan: http://usecloudman.org/
+.. _CloudMan: https://wiki.galaxyproject.org/CloudMan
 .. _Galaxy: http://usegalaxy.org/
 .. _Git repository: https://github.com/afgane/bioblend

--- a/README.rst
+++ b/README.rst
@@ -31,5 +31,5 @@ Full docs are available at http://bioblend.readthedocs.org with a quick library
 overview also available in `ABOUT.rst <./ABOUT.rst>`_.
 
 .. References/hyperlinks used above
-.. _CloudMan: http://usecloudman.org/
+.. _CloudMan: https://wiki.galaxyproject.org/CloudMan
 .. _Galaxy: http://usegalaxy.org/


### PR DESCRIPTION
This is not cloudman: http://usecloudman.org :)
Thanks for reporting @blankclemens