### PR TITLE
Change method name as same as actual behavior

### DIFF
--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -140,7 +140,7 @@ class WorkflowClient(Client):
         url = _join(url, 'import')
         return self._post(url=url, payload=payload)
 
-    def export_workflow_json(self, workflow_id):
+    def export_workflow_dict(self, workflow_id):
         """
         Exports a workflow
 


### PR DESCRIPTION
export_workflow_json method is not return json.

Actual case and in the document , the method returns dict not JSON.

```
        :rtype: dict
        :return: Dict representing the workflow requested
```

It's very confused...