### PR TITLE
Remove custom tool state handling

### DIFF
--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -168,9 +168,6 @@ class Step(Wrapper):
         if stype not in set(['data_collection_input', 'data_input', 'pause',
                              'tool']):
             raise ValueError('Unknown step type: %r' % stype)
-        if self.type == 'tool' and self.tool_inputs:
-            for k, v in six.iteritems(self.tool_inputs):
-                self.tool_inputs[k] = json.loads(v)
 
     @property
     def gi_module(self):


### PR DESCRIPTION
The json.loads here is strange for nested parameters like repeats, sections and conditionals, properly decoding the parameters would be the right thing to do. Alternatively I can make consistent adjustments such as loading or decoding the states dictionary on the side of Galaxy. The location at which all Step input states are stored is here: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/workflow/modules.py#L72. I believe that we have quite some flexibility in the storing format at this point and it would be great to talk about what the preferred format is. ping @jmchilton 