### PR TITLE
Update import_shared_workflow

### DIFF
--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -127,8 +127,8 @@ class WorkflowClient(Client):
         """
         Imports a new workflow from the shared published workflows.
 
-        :type shared_workflow_id: str
-        :param shared_workflow_id: Encoded workflow ID
+        :type workflow_id: str
+        :param workflow_id: Encoded workflow ID
 
         :rtype: dict
         :return: A description of the workflow.

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -141,7 +141,7 @@ class WorkflowClient(Client):
              u'tags': [],
              u'url': u'/api/workflows/ee0e2b4b696d9092'}
         """
-        payload = {'shared_workflow_id': shared_workflow_id}
+        payload = {'shared_workflow_id': workflow_id}
         url = self.gi._make_url(self)
         return self._post(url=url, payload=payload)
 

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -123,12 +123,12 @@ class WorkflowClient(Client):
 
         return self.import_workflow_json(workflow_json)
 
-    def import_shared_workflow(self, workflow_id):
+    def import_shared_workflow(self, shared_workflow_id):
         """
         Imports a new workflow from the shared published workflows.
 
-        :type workflow_id: str
-        :param workflow_id: Encoded workflow ID
+        :type shared_workflow_id: str
+        :param shared_workflow_id: Encoded workflow ID
 
         :rtype: dict
         :return: A description of the workflow.
@@ -140,11 +140,9 @@ class WorkflowClient(Client):
              u'published': False,
              u'tags': [],
              u'url': u'/api/workflows/ee0e2b4b696d9092'}
-
         """
-        payload = {'workflow_id': workflow_id}
+        payload = {'shared_workflow_id': shared_workflow_id}
         url = self.gi._make_url(self)
-        url = _join(url, 'import')
         return self._post(url=url, payload=payload)
 
     def export_workflow_dict(self, workflow_id):

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -123,7 +123,7 @@ class WorkflowClient(Client):
 
         return self.import_workflow_json(workflow_json)
 
-    def import_shared_workflow(self, shared_workflow_id):
+    def import_shared_workflow(self, workflow_id):
         """
         Imports a new workflow from the shared published workflows.
 


### PR DESCRIPTION
/api/workflows/import is deprecated since Galaxy release_14.10.
Update this method to use the new way to import shared workflow