### PR TITLE
More API Coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,17 @@
 * Added ``reload_data_table()`` method to ``ToolDataClient`` (thanks to Marius
   van den Beek).
 
+* Added ``create_folder()``, ``update_folder()``, ``get_permissions()``,
+  ``set_permissions()`` methods to ``FoldersClient`` (thanks to Eric Rasche).
+
+* Added ``get_version()`` method to ``ConfigClient`` (thanks to Eric Rasche).
+
+* Added ``get_user_apikey()`` method to ``UserClient`` (thanks to Eric Rasche).
+
 * Added ``purge`` parameter to ``HistoryClient.delete_dataset()`` method.
+
+* Added ``f_email``, ``f_name``, and ``f_any`` parameters to
+  ``UserClient.get_users()`` method (thanks to Eric Rasche).
 
 * Updated ``WorkflowClient.import_shared_workflow()`` method to use the newer
   Galaxy API request (thanks to @DamCorreia).

--- a/bioblend/galaxy/config/__init__.py
+++ b/bioblend/galaxy/config/__init__.py
@@ -35,3 +35,18 @@ class ConfigClient(Client):
              u'wiki_url': u'https://galaxyproject.org/'}
         """
         return self._get()
+
+    def get_version(self):
+        """
+        Get the current version of the Galaxy instance.
+
+        :rtype: dict
+        :return: Version of the Galaxy instance
+
+        For example::
+
+            {'extra': {}, 'version_major': '17.01'}
+        """
+        url = self.gi._make_url(self, None)
+        url = url.rstrip('configuration') + 'version'
+        return self._get(url=url)

--- a/bioblend/galaxy/config/__init__.py
+++ b/bioblend/galaxy/config/__init__.py
@@ -39,6 +39,7 @@ class ConfigClient(Client):
     def get_version(self):
         """
         Get the current version of the Galaxy instance.
+        This functionality is available since Galaxy ``release_15.03``.
 
         :rtype: dict
         :return: Version of the Galaxy instance

--- a/bioblend/galaxy/toolshed/__init__.py
+++ b/bioblend/galaxy/toolshed/__init__.py
@@ -113,7 +113,7 @@ class ToolShedClient(Client):
         :type install_resolver_dependencies: bool
         :param install_resolver_dependencies: Whether or not to automatically
                                                 install resolver dependencies (e.g. conda).
-                                                This parameter is silently ignored in Galaxy ``release_2016.04`` and earlier.
+                                                This parameter is silently ignored in Galaxy ``release_16.04`` and earlier.
 
         :type tool_panel_section_id: str
         :param tool_panel_section_id: The ID of the Galaxy tool panel section

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -17,9 +17,10 @@ class UserClient(Client):
         Get a list of all registered users. If ``deleted`` is set to ``True``,
         get a list of deleted users.
 
-        The f_email, f_name, and f_any parameters will work for non-admin users
-        only if the Galaxy instance sets expose_user_email and expose_user_name.
-        The `corresponding Galaxy documentation <https://docs.galaxyproject.org/en/master/lib/galaxy.webapps.galaxy.api.html#galaxy.webapps.galaxy.api.users.UserAPIController.index>`__
+        The ``f_email``, ``f_name``, and ``f_any`` parameters will work for
+        non-admin users only if the Galaxy instance sets expose_user_email and
+        expose_user_name. The `corresponding Galaxy documentation
+        <https://docs.galaxyproject.org/en/master/lib/galaxy.webapps.galaxy.api.html#galaxy.webapps.galaxy.api.users.UserAPIController.index>`__
         has further information.
 
         :type f_email: str

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -12,10 +12,24 @@ class UserClient(Client):
         self.module = 'users'
         super(UserClient, self).__init__(galaxy_instance)
 
-    def get_users(self, deleted=False):
+    def get_users(self, deleted=False, f_email=None, f_name=None, f_any=None):
         """
         Get a list of all registered users. If ``deleted`` is set to ``True``,
         get a list of deleted users.
+
+        The f_email, f_name, and f_any parameters will work for non-admin users
+        only if the Galaxy instance sets expose_user_email and expose_user_name.
+        The `corresponding Galaxy documentation <https://docs.galaxyproject.org/en/master/lib/galaxy.webapps.galaxy.api.html#galaxy.webapps.galaxy.api.users.UserAPIController.index>`__
+        has further information.
+
+        :type f_email: str
+        :param f_email: filter for user emails
+
+        :type f_name: str
+        :param f_name: filter for user names
+
+        :type f_any: str
+        :param f_any: filter for user email or name
 
         :rtype: list
         :return: a list of dicts with user details.
@@ -26,7 +40,14 @@ class UserClient(Client):
                      u'url': u'/api/users/dda47097d9189f15'}]
 
         """
-        return self._get(deleted=deleted)
+        params = {}
+        if f_email:
+            params['f_email'] = f_email
+        if f_name:
+            params['f_name'] = f_name
+        if f_any:
+            params['f_any'] = f_any
+        return self._get(deleted=deleted, params=params)
 
     def show_user(self, user_id, deleted=False):
         """

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -166,3 +166,21 @@ class UserClient(Client):
         if purge is True:
             params['purge'] = purge
         return self._delete(id=user_id, params=params)
+
+    def get_user_apikey(self, user_id):
+        """
+        Get the current API key for a given user.
+
+        :type user_id: str
+        :param user_id: encoded user ID
+
+        :rtype: str
+        :return: the API key for the user
+        """
+
+        url = self.gi._make_url(self, None)
+        url = '/'.join([url, user_id, 'api_key', 'inputs'])
+        payload = {}
+        payload['user_id'] = user_id
+
+        return self._get(payload, url=url)['inputs'][0]['value']

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -17,20 +17,26 @@ class UserClient(Client):
         Get a list of all registered users. If ``deleted`` is set to ``True``,
         get a list of deleted users.
 
-        The ``f_email``, ``f_name``, and ``f_any`` parameters will work for
-        non-admin users only if the Galaxy instance sets expose_user_email and
-        expose_user_name. The `corresponding Galaxy documentation
-        <https://docs.galaxyproject.org/en/master/lib/galaxy.webapps.galaxy.api.html#galaxy.webapps.galaxy.api.users.UserAPIController.index>`__
-        has further information.
-
         :type f_email: str
-        :param f_email: filter for user emails
+        :param f_email: filter for user emails. The filter will be active for
+            non-admin users only if the Galaxy instance has the
+            ``expose_user_email`` option set to ``True`` in the
+            ``config/galaxy.ini`` configuration file. This parameter is silently
+            ignored for non-admin users in Galaxy ``release_15.01`` and earlier.
 
         :type f_name: str
-        :param f_name: filter for user names
+        :param f_name: filter for user names. The filter will be active for
+            non-admin users only if the Galaxy instance has the
+            ``expose_user_name`` option set to ``True`` in the
+            ``config/galaxy.ini`` configuration file. This parameter is silently
+            ignored in Galaxy ``release_15.10`` and earlier.
 
         :type f_any: str
-        :param f_any: filter for user email or name
+        :param f_any: filter for user email or name. Each filter will be active
+            for non-admin users only if the Galaxy instance has the
+            corresponding ``expose_user_*`` option set to ``True`` in the
+            ``config/galaxy.ini`` configuration file. This parameter is silently
+            ignored in Galaxy ``release_15.10`` and earlier.
 
         :rtype: list
         :return: a list of dicts with user details.
@@ -171,6 +177,7 @@ class UserClient(Client):
     def get_user_apikey(self, user_id):
         """
         Get the current API key for a given user.
+        This functionality is available since Galaxy ``release_17.01``.
 
         :type user_id: str
         :param user_id: encoded user ID
@@ -181,7 +188,5 @@ class UserClient(Client):
 
         url = self.gi._make_url(self, None)
         url = '/'.join([url, user_id, 'api_key', 'inputs'])
-        payload = {}
-        payload['user_id'] = user_id
 
-        return self._get(payload, url=url)['inputs'][0]['value']
+        return self._get(url=url)['inputs'][0]['value']


### PR DESCRIPTION
As I'm playing more with parsec, I'm finding some other features not well covered so here's a PR with them. It is not a coherent collection of stuff, my apologies.

- get_users now supports server side filtering that's available
- there's a function to get a user's API key without resetting it.
- /api/version