### PR TITLE
Check for mismatching content size only when not streaming to file

### DIFF
--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -107,10 +107,10 @@ class DatasetClient(Client):
         stream_content = file_path is not None
         r = requests.get(url, verify=self.gi.verify, stream=stream_content)
         r.raise_for_status()
-        if 'content-length' in r.headers and len(r.content) != int(r.headers['content-length']):
-            log.warn("Transferred content size does not match content-length header (%s != %s)" % (len(r.content), r.headers['content-length']))
 
         if file_path is None:
+            if 'content-length' in r.headers and len(r.content) != int(r.headers['content-length']):
+                log.warn("Transferred content size does not match content-length header (%s != %s)" % (len(r.content), r.headers['content-length']))
             return r.content
         else:
             if use_default_filename:


### PR DESCRIPTION
Otherwise the file is downloaded in memory for the check.

Reported by @glormph.