### PR TITLE
'create_role' method for BioBlend

### DIFF
--- a/bioblend/_tests/TestGalaxyRoles.py
+++ b/bioblend/_tests/TestGalaxyRoles.py
@@ -4,13 +4,30 @@ credentials to supported cloud infrastructure.
 
 Use ``nose`` to run these unit tests.
 """
+import uuid
+
 from . import GalaxyTestBase
 
 
 class TestGalaxyRoles(GalaxyTestBase.GalaxyTestBase):
+
+    def setUp(self):
+        super(TestGalaxyRoles, self).setUp()
+        self.name = 'test_%s' % uuid.uuid4().hex
+        self.description = 'automated test role'
+        self.role = self.gi.roles.create_role(self.name)[0]
+
+    def tearDown(self):
+        # As of 2017/07/26, deleting a role is not possible through the API
+        pass
 
     def test_get_roles(self):
         roles = self.gi.roles.get_roles()
         for role in roles:
             self.assertIsNotNone(role['id'])
             self.assertIsNotNone(role['name'])
+
+    def test_create_role(self):
+        self.assertEqual(self.role['name'], self.name)
+        self.assertEqual(self.role['description'], self.description)
+        self.assertIsNotNone(self.role['id'])

--- a/bioblend/_tests/TestGalaxyRoles.py
+++ b/bioblend/_tests/TestGalaxyRoles.py
@@ -15,7 +15,7 @@ class TestGalaxyRoles(GalaxyTestBase.GalaxyTestBase):
         super(TestGalaxyRoles, self).setUp()
         self.name = 'test_%s' % uuid.uuid4().hex
         self.description = 'automated test role'
-        self.role = self.gi.roles.create_role(self.name)[0]
+        self.role = self.gi.roles.create_role(self.name, self.description)[0]
 
     def tearDown(self):
         # As of 2017/07/26, deleting a role is not possible through the API

--- a/bioblend/galaxy/roles/__init__.py
+++ b/bioblend/galaxy/roles/__init__.py
@@ -48,3 +48,38 @@ class RolesClient(Client):
              "url": "/api/roles/f2db41e1fa331b3e"}
         """
         return self._get(id=role_id)
+
+    def create_role(self, role_name, description, user_ids=[], role_ids=[]):
+        """
+        Create a new role.
+
+        :type role_name: str
+        :param role_name: A name for the new role
+
+        :type description: str
+        :param description: Description for the new role
+
+        :type user_ids: list
+        :param user_ids: A list of encoded user IDs to add to the new role
+
+        :type group_ids: list
+        :param group_ids: A list of encoded group IDs to add to the new role
+
+        :rtype: list
+        :return: A (size 1) list with newly created role
+          details, like::
+
+            [{u'description': u'desc', 
+              u'url': u'/api/roles/ebfb8f50c6abde6d', 
+              u'model_class': u'Role', 
+              u'type': u'admin', 
+              u'id': u'ebfb8f50c6abde6d', 
+              u'name': u'role3'}]
+        """
+        payload = {
+            'name': role_name,
+            'description': description,
+            'user_ids': user_ids,
+            'role_ids': role_ids
+        }
+        return self._post(payload)

--- a/bioblend/galaxy/roles/__init__.py
+++ b/bioblend/galaxy/roles/__init__.py
@@ -49,7 +49,7 @@ class RolesClient(Client):
         """
         return self._get(id=role_id)
 
-    def create_role(self, role_name, description, user_ids=[], role_ids=[]):
+    def create_role(self, role_name, description, user_ids=[], group_ids=[]):
         """
         Create a new role.
 
@@ -80,6 +80,6 @@ class RolesClient(Client):
             'name': role_name,
             'description': description,
             'user_ids': user_ids,
-            'role_ids': role_ids
+            'group_ids': group_ids
         }
         return self._post(payload)

--- a/bioblend/galaxy/roles/__init__.py
+++ b/bioblend/galaxy/roles/__init__.py
@@ -74,7 +74,7 @@ class RolesClient(Client):
               u'model_class': u'Role', 
               u'type': u'admin', 
               u'id': u'ebfb8f50c6abde6d', 
-              u'name': u'role3'}]
+              u'name': u'Foo'}]
         """
         payload = {
             'name': role_name,

--- a/bioblend/galaxy/roles/__init__.py
+++ b/bioblend/galaxy/roles/__init__.py
@@ -69,11 +69,11 @@ class RolesClient(Client):
         :return: A (size 1) list with newly created role
           details, like::
 
-            [{u'description': u'desc', 
-              u'url': u'/api/roles/ebfb8f50c6abde6d', 
-              u'model_class': u'Role', 
-              u'type': u'admin', 
-              u'id': u'ebfb8f50c6abde6d', 
+            [{u'description': u'desc',
+              u'url': u'/api/roles/ebfb8f50c6abde6d',
+              u'model_class': u'Role',
+              u'type': u'admin',
+              u'id': u'ebfb8f50c6abde6d',
               u'name': u'Foo'}]
         """
         payload = {


### PR DESCRIPTION
This PR will enable the admin users to create a new role using Bioblend. 