### PR TITLE
histories.delete_dataset dataset_id -> hda_id

### DIFF
--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -131,7 +131,7 @@ class HistoryClient(Client):
         """
         url = self.gi._make_url(self, history_id, contents=True)
         # Append the dataset_id to the base history contents URL
-        url = '/'.join([url, dataset_id])
+        url = '/'.join([url, hda_id])
         payload = {}
         if purge is True:
             payload['purge'] = purge

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -105,15 +105,15 @@ class HistoryClient(Client):
                 params['types'] = types.join(",")
         return self._get(id=history_id, contents=contents, params=params)
 
-    def delete_dataset(self, history_id, dataset_id, purge=False):
+    def delete_dataset(self, history_id, hda_id, purge=False):
         """
         Mark corresponding dataset as deleted.
 
         :type history_id: str
         :param history_id: Encoded history ID
 
-        :type dataset_id: str
-        :param dataset_id: Encoded dataset ID
+        :type hda_id: str
+        :param hda_id: Encoded history_dataset_association ID
 
         :type purge: bool
         :param purge: if ``True``, also purge (permanently delete) the dataset


### PR DESCRIPTION
I'm not sure at 100% but I believe that `dataset_id` is confusing because in this case, you delete [and purge] the `history_dataset_association` not the dataset directly.

And eventually, you delete and purge the dataset if there isn't any other "association".
At least, it is what I have discovered :)