### PR TITLE
Feature/import public workflow

### DIFF
--- a/bioblend/_tests/TestGalaxyObjects.py
+++ b/bioblend/_tests/TestGalaxyObjects.py
@@ -100,7 +100,6 @@ def upload_from_fs(lib, bnames, **kwargs):
 
 
 class MockWrapper(wrappers.Wrapper):
-
     BASE_ATTRS = frozenset(['a', 'b'])
 
     def __init__(self, *args, **kwargs):
@@ -112,7 +111,6 @@ class MockWrapper(wrappers.Wrapper):
 
 
 class TestWrapper(unittest.TestCase):
-
     def setUp(self):
         self.d = {'a': 1, 'b': [2, 3], 'c': {'x': 4}}
         self.assertRaises(TypeError, wrappers.Wrapper, self.d)
@@ -153,7 +151,6 @@ class TestWrapper(unittest.TestCase):
 
 
 class TestWorkflow(unittest.TestCase):
-
     def setUp(self):
         self.wf = wrappers.Workflow(SAMPLE_WF_DICT)
 
@@ -207,6 +204,7 @@ class TestWorkflow(unittest.TestCase):
 
             def __init__(self, id_):
                 self.id = id_
+
         label = 'Input Dataset'
         self.assertEqual(self.wf.input_labels, set([label]))
         input_map = self.wf.convert_input_map(
@@ -223,7 +221,6 @@ class TestWorkflow(unittest.TestCase):
 
 @test_util.skip_unless_galaxy()
 class GalaxyObjectsTestBase(unittest.TestCase):
-
     def setUp(self):
         galaxy_key = os.environ['BIOBLEND_GALAXY_API_KEY']
         galaxy_url = os.environ['BIOBLEND_GALAXY_URL']
@@ -231,7 +228,6 @@ class GalaxyObjectsTestBase(unittest.TestCase):
 
 
 class TestGalaxyInstance(GalaxyObjectsTestBase):
-
     def test_library(self):
         name = 'test_%s' % uuid.uuid4().hex
         description, synopsis = 'D', 'S'
@@ -354,6 +350,7 @@ class TestGalaxyInstance(GalaxyObjectsTestBase):
                     d = json.load(f)
                 d['name'] = name
                 return self.gi.workflows.import_new(d)
+
             get_objs = self.gi.workflows.list
             get_prevs = self.gi.workflows.get_previews
             del_kwargs = {}
@@ -365,6 +362,7 @@ class TestGalaxyInstance(GalaxyObjectsTestBase):
 
         def ids(seq):
             return set(_.id for _ in seq)
+
         names = ['test_%s' % uuid.uuid4().hex for _ in range(2)]
         objs = []
         try:
@@ -411,7 +409,6 @@ class TestGalaxyInstance(GalaxyObjectsTestBase):
 
 
 class TestLibrary(GalaxyObjectsTestBase):
-
     # just something that can be expected to be always up
     DS_URL = 'http://tools.ietf.org/rfc/rfc1866.txt'
 
@@ -502,7 +499,6 @@ class TestLibrary(GalaxyObjectsTestBase):
 
 
 class TestLDContents(GalaxyObjectsTestBase):
-
     def setUp(self):
         super(TestLDContents, self).setUp()
         self.lib = self.gi.libraries.create('test_%s' % uuid.uuid4().hex)
@@ -537,7 +533,6 @@ class TestLDContents(GalaxyObjectsTestBase):
 
 
 class TestHistory(GalaxyObjectsTestBase):
-
     def setUp(self):
         super(TestHistory, self).setUp()
         self.hist = self.gi.histories.create('test_%s' % uuid.uuid4().hex)
@@ -657,7 +652,6 @@ class TestHistory(GalaxyObjectsTestBase):
 
 
 class TestHDAContents(GalaxyObjectsTestBase):
-
     def setUp(self):
         super(TestHDAContents, self).setUp()
         self.hist = self.gi.histories.create('test_%s' % uuid.uuid4().hex)
@@ -707,7 +701,6 @@ class TestHDAContents(GalaxyObjectsTestBase):
 
 
 class TestRunWorkflow(GalaxyObjectsTestBase):
-
     def setUp(self):
         super(TestRunWorkflow, self).setUp()
         self.lib = self.gi.libraries.create('test_%s' % uuid.uuid4().hex)
@@ -758,7 +751,6 @@ class TestRunWorkflow(GalaxyObjectsTestBase):
 
 
 class TestRunDatasetCollectionWorkflow(GalaxyObjectsTestBase):
-
     def setUp(self):
         super(TestRunDatasetCollectionWorkflow, self).setUp()
         with open(SAMPLE_WF_COLL_FN) as f:
@@ -792,7 +784,6 @@ class TestRunDatasetCollectionWorkflow(GalaxyObjectsTestBase):
 
 
 class TestJob(GalaxyObjectsTestBase):
-
     def setUp(self):
         super(TestJob, self).setUp()
 

--- a/bioblend/_tests/TestGalaxyObjects.py
+++ b/bioblend/_tests/TestGalaxyObjects.py
@@ -262,6 +262,11 @@ class TestGalaxyInstance(GalaxyObjectsTestBase):
             wf = self.gi.workflows.import_new(json.load(f))
         self._check_and_del_workflow(wf)
 
+    def test_workflow_publish_from_dict(self):
+        with open(SAMPLE_FN) as f:
+            wf = self.gi.workflows.import_new(json.load(f), publish=True)
+        self._check_and_del_workflow(wf, check_is_public=True)
+
     def test_workflow_missing_tools(self):
         with open(SAMPLE_FN) as f:
             wf_dump = json.load(f)
@@ -284,7 +289,7 @@ class TestGalaxyInstance(GalaxyObjectsTestBase):
         for wf in wf1, wf2:
             self._check_and_del_workflow(wf)
 
-    def _check_and_del_workflow(self, wf):
+    def _check_and_del_workflow(self, wf, check_is_public=False):
         # Galaxy appends additional text to imported workflow names
         self.assertTrue(wf.name.startswith('paste_columns'))
         self.assertEqual(len(wf.steps), 3)
@@ -302,6 +307,8 @@ class TestGalaxyInstance(GalaxyObjectsTestBase):
                 self.assertEqual(step.input_steps, {})
         wf_ids = set(_.id for _ in self.gi.workflows.list())
         self.assertIn(wf.id, wf_ids)
+        if check_is_public:
+            self.assertTrue(wf.published)
         wf.delete()
 
     # not very accurate:

--- a/bioblend/_tests/TestGalaxyObjects.py
+++ b/bioblend/_tests/TestGalaxyObjects.py
@@ -111,6 +111,7 @@ class MockWrapper(wrappers.Wrapper):
 
 
 class TestWrapper(unittest.TestCase):
+
     def setUp(self):
         self.d = {'a': 1, 'b': [2, 3], 'c': {'x': 4}}
         self.assertRaises(TypeError, wrappers.Wrapper, self.d)
@@ -151,6 +152,7 @@ class TestWrapper(unittest.TestCase):
 
 
 class TestWorkflow(unittest.TestCase):
+
     def setUp(self):
         self.wf = wrappers.Workflow(SAMPLE_WF_DICT)
 
@@ -221,6 +223,7 @@ class TestWorkflow(unittest.TestCase):
 
 @test_util.skip_unless_galaxy()
 class GalaxyObjectsTestBase(unittest.TestCase):
+
     def setUp(self):
         galaxy_key = os.environ['BIOBLEND_GALAXY_API_KEY']
         galaxy_url = os.environ['BIOBLEND_GALAXY_URL']
@@ -228,6 +231,7 @@ class GalaxyObjectsTestBase(unittest.TestCase):
 
 
 class TestGalaxyInstance(GalaxyObjectsTestBase):
+
     def test_library(self):
         name = 'test_%s' % uuid.uuid4().hex
         description, synopsis = 'D', 'S'
@@ -499,6 +503,7 @@ class TestLibrary(GalaxyObjectsTestBase):
 
 
 class TestLDContents(GalaxyObjectsTestBase):
+
     def setUp(self):
         super(TestLDContents, self).setUp()
         self.lib = self.gi.libraries.create('test_%s' % uuid.uuid4().hex)
@@ -533,6 +538,7 @@ class TestLDContents(GalaxyObjectsTestBase):
 
 
 class TestHistory(GalaxyObjectsTestBase):
+
     def setUp(self):
         super(TestHistory, self).setUp()
         self.hist = self.gi.histories.create('test_%s' % uuid.uuid4().hex)
@@ -652,6 +658,7 @@ class TestHistory(GalaxyObjectsTestBase):
 
 
 class TestHDAContents(GalaxyObjectsTestBase):
+
     def setUp(self):
         super(TestHDAContents, self).setUp()
         self.hist = self.gi.histories.create('test_%s' % uuid.uuid4().hex)
@@ -701,6 +708,7 @@ class TestHDAContents(GalaxyObjectsTestBase):
 
 
 class TestRunWorkflow(GalaxyObjectsTestBase):
+
     def setUp(self):
         super(TestRunWorkflow, self).setUp()
         self.lib = self.gi.libraries.create('test_%s' % uuid.uuid4().hex)
@@ -751,6 +759,7 @@ class TestRunWorkflow(GalaxyObjectsTestBase):
 
 
 class TestRunDatasetCollectionWorkflow(GalaxyObjectsTestBase):
+
     def setUp(self):
         super(TestRunDatasetCollectionWorkflow, self).setUp()
         with open(SAMPLE_WF_COLL_FN) as f:
@@ -784,6 +793,7 @@ class TestRunDatasetCollectionWorkflow(GalaxyObjectsTestBase):
 
 
 class TestJob(GalaxyObjectsTestBase):
+
     def setUp(self):
         super(TestJob, self).setUp()
 

--- a/bioblend/_tests/TestGalaxyWorkflows.py
+++ b/bioblend/_tests/TestGalaxyWorkflows.py
@@ -13,7 +13,6 @@ from . import GalaxyTestBase, test_util
 
 
 class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
-
     @test_util.skip_unless_galaxy('release_15.03')
     @test_util.skip_unless_tool("cat1")
     @test_util.skip_unless_tool("cat")
@@ -50,7 +49,8 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
 
         steps = invocation_steps_by_order_index()
         pause_step = steps[2]
-        self.assertIsNone(self.gi.workflows.show_invocation_step(workflow_id, invocation_id, pause_step["id"])["action"])
+        self.assertIsNone(
+            self.gi.workflows.show_invocation_step(workflow_id, invocation_id, pause_step["id"])["action"])
         self.gi.workflows.run_invocation_step_action(workflow_id, invocation_id, pause_step["id"], action=True)
         self.assertTrue(self.gi.workflows.show_invocation_step(workflow_id, invocation_id, pause_step["id"])["action"])
         for i in range(20):
@@ -99,6 +99,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         imported_wf = self.gi.workflows.import_workflow_from_local_path(path)
         self.assertIsInstance(imported_wf, dict)
         self.assertFalse(imported_wf['deleted'])
+        self.assertFalse(imported_wf['published'])
         with self.assertRaises(Exception):
             self.gi.workflows.export_workflow_to_local_path(None, None, None)
         export_dir = tempfile.mkdtemp(prefix='bioblend_test_')
@@ -113,6 +114,15 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
             shutil.rmtree(export_dir)
         self.assertIsInstance(exported_wf_dict, dict)
 
+    def test_import_publish_export_workflow_from_local_path(self):
+        with self.assertRaises(Exception):
+            self.gi.workflows.import_workflow_from_local_path(None)
+        path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
+        imported_wf = self.gi.workflows.import_workflow_from_local_path(path, publish=True)
+        self.assertIsInstance(imported_wf, dict)
+        self.assertFalse(imported_wf['deleted'])
+        self.assertTrue(imported_wf['published'])
+
     def test_import_export_workflow_dict(self):
         path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
         with open(path, 'r') as f:
@@ -120,8 +130,18 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         imported_wf = self.gi.workflows.import_workflow_dict(wf_dict)
         self.assertIsInstance(imported_wf, dict)
         self.assertFalse(imported_wf['deleted'])
+        self.assertFalse(imported_wf['published'])
         exported_wf_dict = self.gi.workflows.export_workflow_dict(imported_wf['id'])
         self.assertIsInstance(exported_wf_dict, dict)
+
+    def test_import_publish_export_workflow_dict(self):
+        path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
+        with open(path, 'r') as f:
+            wf_dict = json.load(f)
+        imported_wf = self.gi.workflows.import_workflow_dict(wf_dict, publish=True)
+        self.assertIsInstance(imported_wf, dict)
+        self.assertFalse(imported_wf['deleted'])
+        self.assertTrue(imported_wf['published'])
 
     def test_get_workflows(self):
         path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))

--- a/bioblend/_tests/TestGalaxyWorkflows.py
+++ b/bioblend/_tests/TestGalaxyWorkflows.py
@@ -13,6 +13,7 @@ from . import GalaxyTestBase, test_util
 
 
 class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
+
     @test_util.skip_unless_galaxy('release_15.03')
     @test_util.skip_unless_tool("cat1")
     @test_util.skip_unless_tool("cat")

--- a/bioblend/_tests/TestGalaxyWorkflows.py
+++ b/bioblend/_tests/TestGalaxyWorkflows.py
@@ -115,8 +115,6 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         self.assertIsInstance(exported_wf_dict, dict)
 
     def test_import_publish_workflow_from_local_path(self):
-        with self.assertRaises(Exception):
-            self.gi.workflows.import_workflow_from_local_path(None)
         path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
         imported_wf = self.gi.workflows.import_workflow_from_local_path(path, publish=True)
         self.assertIsInstance(imported_wf, dict)

--- a/bioblend/_tests/TestGalaxyWorkflows.py
+++ b/bioblend/_tests/TestGalaxyWorkflows.py
@@ -114,7 +114,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
             shutil.rmtree(export_dir)
         self.assertIsInstance(exported_wf_dict, dict)
 
-    def test_import_publish_export_workflow_from_local_path(self):
+    def test_import_publish_workflow_from_local_path(self):
         with self.assertRaises(Exception):
             self.gi.workflows.import_workflow_from_local_path(None)
         path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
@@ -134,7 +134,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         exported_wf_dict = self.gi.workflows.export_workflow_dict(imported_wf['id'])
         self.assertIsInstance(exported_wf_dict, dict)
 
-    def test_import_publish_export_workflow_dict(self):
+    def test_import_publish_workflow_dict(self):
         path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
         with open(path, 'r') as f:
             wf_dict = json.load(f)

--- a/bioblend/galaxy/objects/client.py
+++ b/bioblend/galaxy/objects/client.py
@@ -245,6 +245,10 @@ class ObjWorkflowClient(ObjClient):
           dump of the workflow (this is normally obtained by exporting
           a workflow from Galaxy).
 
+        :type publish: bool
+        :param publish:  if ``True`` the uploaded workflow will be sharable;
+                         otherwise it will be visible only by the user which uploads it (default).
+
         :rtype: :class:`~.wrappers.Workflow`
         :return: the workflow just imported
         """

--- a/bioblend/galaxy/objects/client.py
+++ b/bioblend/galaxy/objects/client.py
@@ -236,7 +236,7 @@ class ObjWorkflowClient(ObjClient):
     def __init__(self, obj_gi):
         super(ObjWorkflowClient, self).__init__(obj_gi)
 
-    def import_new(self, src):
+    def import_new(self, src, publish=False):
         """
         Imports a new workflow into Galaxy.
 
@@ -255,7 +255,7 @@ class ObjWorkflowClient(ObjClient):
                 wf_dict = json.loads(src)
             except (TypeError, ValueError):
                 self._error('src not supported: %r' % (src,))
-        wf_info = self.gi.workflows.import_workflow_dict(wf_dict)
+        wf_info = self.gi.workflows.import_workflow_dict(wf_dict, publish)
         return self.get(wf_info['id'])
 
     def import_shared(self, id_):

--- a/bioblend/galaxy/objects/client.py
+++ b/bioblend/galaxy/objects/client.py
@@ -16,7 +16,6 @@ from . import wrappers
 
 @six.add_metaclass(abc.ABCMeta)
 class ObjClient(object):
-
     @abc.abstractmethod
     def __init__(self, obj_gi):
         self.obj_gi = obj_gi
@@ -80,7 +79,6 @@ class ObjClient(object):
 
 
 class ObjDatasetContainerClient(ObjClient):
-
     def _get_container(self, id_, ctype):
         show_fname = 'show_%s' % ctype.__name__.lower()
         gi_client = getattr(self.gi, ctype.API_MODULE)
@@ -99,6 +97,7 @@ class ObjLibraryClient(ObjDatasetContainerClient):
     """
     Interacts with Galaxy libraries.
     """
+
     def __init__(self, obj_gi):
         super(ObjLibraryClient, self).__init__(obj_gi)
 
@@ -326,6 +325,7 @@ class ObjToolClient(ObjClient):
     """
     Interacts with Galaxy tools.
     """
+
     def __init__(self, obj_gi):
         super(ObjToolClient, self).__init__(obj_gi)
 
@@ -393,6 +393,7 @@ class ObjJobClient(ObjClient):
     """
     Interacts with Galaxy jobs.
     """
+
     def __init__(self, obj_gi):
         super(ObjJobClient, self).__init__(obj_gi)
 

--- a/bioblend/galaxy/objects/client.py
+++ b/bioblend/galaxy/objects/client.py
@@ -245,7 +245,7 @@ class ObjWorkflowClient(ObjClient):
           a workflow from Galaxy).
 
         :type publish: bool
-        :param publish:  if ``True`` the uploaded workflow will be sharable;
+        :param publish:  if ``True`` the uploaded workflow will be published;
                          otherwise it will be visible only by the user which uploads it (default).
 
         :rtype: :class:`~.wrappers.Workflow`

--- a/bioblend/galaxy/objects/client.py
+++ b/bioblend/galaxy/objects/client.py
@@ -16,6 +16,7 @@ from . import wrappers
 
 @six.add_metaclass(abc.ABCMeta)
 class ObjClient(object):
+
     @abc.abstractmethod
     def __init__(self, obj_gi):
         self.obj_gi = obj_gi
@@ -79,6 +80,7 @@ class ObjClient(object):
 
 
 class ObjDatasetContainerClient(ObjClient):
+
     def _get_container(self, id_, ctype):
         show_fname = 'show_%s' % ctype.__name__.lower()
         gi_client = getattr(self.gi, ctype.API_MODULE)

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -102,14 +102,14 @@ class WorkflowClient(Client):
         url = _join(url, "upload")
         return self._post(url=url, payload=payload)
 
-    def import_workflow_json(self, workflow_json):
+    def import_workflow_json(self, workflow_json, publish=False):
         """
         .. deprecated:: 0.9.0
            Use :meth:`import_workflow_dict` instead.
         """
-        return self.import_workflow_dict(workflow_json)
+        return self.import_workflow_dict(workflow_json, publish)
 
-    def import_workflow_from_local_path(self, file_local_path):
+    def import_workflow_from_local_path(self, file_local_path, publish=False):
         """
         Imports a new workflow given the path to a file containing a previously
         exported workflow.
@@ -120,7 +120,7 @@ class WorkflowClient(Client):
         with open(file_local_path, 'r') as fp:
             workflow_json = json.load(fp)
 
-        return self.import_workflow_json(workflow_json)
+        return self.import_workflow_json(workflow_json, publish)
 
     def import_shared_workflow(self, workflow_id):
         """

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -88,7 +88,7 @@ class WorkflowClient(Client):
         inputs = wf['inputs']
         return [id for id in inputs if inputs[id]['label'] == label]
 
-    def import_workflow_dict(self, workflow_dict):
+    def import_workflow_dict(self, workflow_dict, publish=False):
         """
         Imports a new workflow given a dictionary representing a previously
         exported workflow.
@@ -96,7 +96,7 @@ class WorkflowClient(Client):
         :type workflow_dict: dict
         :param workflow_dict: dictionary representing the workflow to be imported
         """
-        payload = {'workflow': workflow_dict}
+        payload = {'workflow': workflow_dict, 'publish': publish}
 
         url = self.gi._make_url(self)
         url = _join(url, "upload")

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -95,6 +95,10 @@ class WorkflowClient(Client):
 
         :type workflow_dict: dict
         :param workflow_dict: dictionary representing the workflow to be imported
+
+        :type publish: bool
+        :param publish:  if ``True`` the uploaded workflow will be sharable;
+                         otherwise it will be visible only by the user which uploads it (default)
         """
         payload = {'workflow': workflow_dict, 'publish': publish}
 
@@ -106,6 +110,14 @@ class WorkflowClient(Client):
         """
         .. deprecated:: 0.9.0
            Use :meth:`import_workflow_dict` instead.
+
+        :type workflow_json: dict
+        :param workflow_json: dictionary representing the workflow to be imported
+
+        :type publish: bool
+        :param publish:  if ``True`` the uploaded workflow will be sharable;
+                         otherwise it will be visible only by the user which uploads it (default)
+
         """
         return self.import_workflow_dict(workflow_json, publish)
 
@@ -116,6 +128,11 @@ class WorkflowClient(Client):
 
         :type file_local_path: str
         :param file_local_path: File to upload to the server for new workflow
+
+        :type publish: bool
+        :param publish:  if ``True`` the uploaded workflow will be sharable;
+                         otherwise it will be visible only by the user which uploads it (default)
+
         """
         with open(file_local_path, 'r') as fp:
             workflow_json = json.load(fp)
@@ -637,4 +654,4 @@ def _join(*args):
     return "/".join(args)
 
 
-__all__ = ('WorkflowClient', )
+__all__ = ('WorkflowClient',)

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -106,20 +106,16 @@ class WorkflowClient(Client):
         url = _join(url, "upload")
         return self._post(url=url, payload=payload)
 
-    def import_workflow_json(self, workflow_json, publish=False):
+    def import_workflow_json(self, workflow_json):
         """
         .. deprecated:: 0.9.0
            Use :meth:`import_workflow_dict` instead.
 
         :type workflow_json: dict
         :param workflow_json: dictionary representing the workflow to be imported
-
-        :type publish: bool
-        :param publish:  if ``True`` the uploaded workflow will be published;
-                         otherwise it will be visible only by the user which uploads it (default)
-
+        
         """
-        return self.import_workflow_dict(workflow_json, publish)
+        return self.import_workflow_dict(workflow_json)
 
     def import_workflow_from_local_path(self, file_local_path, publish=False):
         """

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -133,7 +133,7 @@ class WorkflowClient(Client):
         with open(file_local_path, 'r') as fp:
             workflow_json = json.load(fp)
 
-        return self.import_workflow_json(workflow_json, publish)
+        return self.import_workflow_dict(workflow_json, publish)
 
     def import_shared_workflow(self, workflow_id):
         """

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -113,7 +113,6 @@ class WorkflowClient(Client):
 
         :type workflow_json: dict
         :param workflow_json: dictionary representing the workflow to be imported
-        
         """
         return self.import_workflow_dict(workflow_json)
 

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -97,7 +97,7 @@ class WorkflowClient(Client):
         :param workflow_dict: dictionary representing the workflow to be imported
 
         :type publish: bool
-        :param publish:  if ``True`` the uploaded workflow will be sharable;
+        :param publish:  if ``True`` the uploaded workflow will be published;
                          otherwise it will be visible only by the user which uploads it (default)
         """
         payload = {'workflow': workflow_dict, 'publish': publish}
@@ -115,7 +115,7 @@ class WorkflowClient(Client):
         :param workflow_json: dictionary representing the workflow to be imported
 
         :type publish: bool
-        :param publish:  if ``True`` the uploaded workflow will be sharable;
+        :param publish:  if ``True`` the uploaded workflow will be published;
                          otherwise it will be visible only by the user which uploads it (default)
 
         """
@@ -130,7 +130,7 @@ class WorkflowClient(Client):
         :param file_local_path: File to upload to the server for new workflow
 
         :type publish: bool
-        :param publish:  if ``True`` the uploaded workflow will be sharable;
+        :param publish:  if ``True`` the uploaded workflow will be published;
                          otherwise it will be visible only by the user which uploads it (default)
 
         """


### PR DESCRIPTION
This PR adds support for publishing workflows when they are imported into Galaxy.

The implementation relies on the already existing support of the same functionality in the Galaxy REST API. Specifically the `POST /api/workflows`and `POST /api/workflows/upload` methods support the `publish` parameter and this PR simply exposes it on BioBlend API.