### PR TITLE
Add a verify option when using the object-oriented API

### DIFF
--- a/bioblend/galaxy/objects/galaxy_instance.py
+++ b/bioblend/galaxy/objects/galaxy_instance.py
@@ -47,8 +47,8 @@ class GalaxyInstance(object):
       gi = GalaxyInstance('http://127.0.0.1:8080', 'foo')
       histories = gi.histories.list()
     """
-    def __init__(self, url, api_key=None, email=None, password=None):
-        self.gi = bioblend.galaxy.GalaxyInstance(url, api_key, email, password)
+    def __init__(self, url, api_key=None, email=None, password=None, verify=True):
+        self.gi = bioblend.galaxy.GalaxyInstance(url, api_key, email, password, verify)
         self.log = bioblend.log
         self.histories = client.ObjHistoryClient(self)
         self.libraries = client.ObjLibraryClient(self)


### PR DESCRIPTION
to match what's available in the regular API. For example, the following works:

    from bioblend.galaxy import GalaxyInstance
    gi = GalaxyInstance(url=..., key=..., verify=False)

but this isn't possible without this PR:

    from bioblend.galaxy.objects import GalaxyInstance
    gi = GalaxyInstance(url=..., api_key=..., verify=False)