### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         'boto>=2.9.7',
         'pyyaml',
-        'requests>=2.4.3,!=2.12.0,!=2.12.1',
+        'requests[security]>=2.4.3,!=2.12.0,!=2.12.1',
         'requests-toolbelt',
         'six'
     ],


### PR DESCRIPTION
requests[security] is required to connect to some https enabled servers ("bad handshake: Error([('SSL routines', 'ssl3_get_server_certificate', 'certificate verify failed')],)",). Traced back this issue from not being able to connect to a Galaxy instance in Jupyter GIE over `galaxy_ie_helpers/__init__.py` line 38 to bioblend. Note: The Galaxy instance has a valid certificate (https://denbi-galaxy.bioquant.uni-heidelberg.de).