### PR TITLE
Add missing api method/arg for data libraries

### DIFF
--- a/bioblend/_tests/TestGalaxyLibraries.py
+++ b/bioblend/_tests/TestGalaxyLibraries.py
@@ -74,6 +74,13 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
         dataset_id = self._test_dataset(history['id'])
         self.gi.libraries.copy_from_dataset(self.library['id'], dataset_id, message='Copied from dataset')
 
+    def test_update_dataset(self):
+        library_id = self.library["id"]
+        dataset1_id = self._test_dataset(library_id)
+        updated_dataset = self.gi.libraries.update_library_dataset(library_id, dataset1_id, name='Modified name', misc_info='Modified the name succesfully')
+        self.assertEqual(updated_dataset["name"], 'Modified name')
+        self.assertEqual(updated_dataset["misc_info"], 'Modified the name succesfully')
+
     @test_util.skip_unless_galaxy('release_14.10')
     def test_library_permissions(self):
         current_user = self.gi.users.get_current_user()

--- a/bioblend/_tests/TestGalaxyLibraries.py
+++ b/bioblend/_tests/TestGalaxyLibraries.py
@@ -74,6 +74,7 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
         dataset_id = self._test_dataset(history['id'])
         self.gi.libraries.copy_from_dataset(self.library['id'], dataset_id, message='Copied from dataset')
 
+    @test_util.skip_unless_galaxy('release_17.09')
     def test_update_dataset(self):
         library_id = self.library["id"]
         dataset1 = self.gi.libraries.upload_file_contents(library_id, FOO_DATA)

--- a/bioblend/_tests/TestGalaxyLibraries.py
+++ b/bioblend/_tests/TestGalaxyLibraries.py
@@ -76,8 +76,8 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
 
     def test_update_dataset(self):
         library_id = self.library["id"]
-        dataset1_id = self._test_dataset(library_id)
-        updated_dataset = self.gi.libraries.update_library_dataset(dataset1_id, name='Modified name', misc_info='Modified the name succesfully')
+        dataset1 = self.gi.libraries.upload_file_contents(library_id, FOO_DATA)
+        updated_dataset = self.gi.libraries.update_library_dataset(dataset1[0]['id'], name='Modified name', misc_info='Modified the name succesfully')
         self.assertEqual(updated_dataset["name"], 'Modified name')
         self.assertEqual(updated_dataset["misc_info"], 'Modified the name succesfully')
 

--- a/bioblend/_tests/TestGalaxyLibraries.py
+++ b/bioblend/_tests/TestGalaxyLibraries.py
@@ -77,7 +77,7 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
     def test_update_dataset(self):
         library_id = self.library["id"]
         dataset1_id = self._test_dataset(library_id)
-        updated_dataset = self.gi.libraries.update_library_dataset(library_id, dataset1_id, name='Modified name', misc_info='Modified the name succesfully')
+        updated_dataset = self.gi.libraries.update_library_dataset(dataset1_id, name='Modified name', misc_info='Modified the name succesfully')
         self.assertEqual(updated_dataset["name"], 'Modified name')
         self.assertEqual(updated_dataset["misc_info"], 'Modified the name succesfully')
 

--- a/bioblend/_tests/TestGalaxyObjects.py
+++ b/bioblend/_tests/TestGalaxyObjects.py
@@ -543,7 +543,7 @@ class TestLDContents(GalaxyObjectsTestBase):
         updated_ldda = self.ds.update(name=new_name, misc_info=new_misc_info, genome_build=new_genome_build)
         self.assertEqual(self.ds.id, updated_ldda.id)
         self.assertEqual(self.ds.name, new_name)
-        self.assertEqual(self.ds.annotation, new_misc_info)
+        self.assertEqual(self.ds.misc_info, new_misc_info)
         self.assertEqual(self.ds.genome_build, new_genome_build)
 
 

--- a/bioblend/_tests/TestGalaxyObjects.py
+++ b/bioblend/_tests/TestGalaxyObjects.py
@@ -536,6 +536,16 @@ class TestLDContents(GalaxyObjectsTestBase):
         # by the API at the moment
         # self.assertTrue(self.ds.deleted)
 
+    def test_dataset_update(self):
+        new_name = 'test_%s' % uuid.uuid4().hex
+        new_misc_info = 'Annotation for %s' % new_name
+        new_genome_build = 'hg19'
+        updated_ldda = self.ds.update(name=new_name, misc_info=new_misc_info, genome_build=new_genome_build)
+        self.assertEqual(self.ds.id, updated_ldda.id)
+        self.assertEqual(self.ds.name, new_name)
+        self.assertEqual(self.ds.annotation, new_misc_info)
+        self.assertEqual(self.ds.genome_build, new_genome_build)
+
 
 class TestHistory(GalaxyObjectsTestBase):
 

--- a/bioblend/_tests/TestGalaxyObjects.py
+++ b/bioblend/_tests/TestGalaxyObjects.py
@@ -536,6 +536,7 @@ class TestLDContents(GalaxyObjectsTestBase):
         # by the API at the moment
         # self.assertTrue(self.ds.deleted)
 
+    @test_util.skip_unless_galaxy('release_17.09')
     def test_dataset_update(self):
         new_name = 'test_%s' % uuid.uuid4().hex
         new_misc_info = 'Annotation for %s' % new_name

--- a/bioblend/galaxy/client.py
+++ b/bioblend/galaxy/client.py
@@ -164,6 +164,19 @@ class Client(object):
             url = self.gi._make_url(self, module_id=id)
         return self.gi.make_put_request(url, payload=payload, params=params)
 
+    def _patch(self, payload, id=None, url=None, params=None):
+        """
+        Do a generic PATCH request, composing the url from the contents of the
+        arguments. Alternatively, an explicit ``url`` can be provided to use
+        for the request. ``payload`` must be a dict that contains additional
+        request arguments which will be sent along with the request body.
+
+        :return: The decoded response.
+        """
+        if not url:
+            url = self.gi._make_url(self, module_id=id)
+        return self.gi.make_patch_request(url, payload=payload, params=params)
+
     def _delete(self, payload=None, id=None, deleted=False, contents=None, url=None, params=None):
         """
         Do a generic DELETE request, composing the url from the contents of the

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -335,6 +335,10 @@ class LibraryClient(Client):
             payload["roles"] = keywords["roles"]
         if keywords.get("link_data_only", None) and keywords['link_data_only'] != 'copy_files':
             payload["link_data_only"] = 'link_to_files'
+        if keywords.get('tag_using_filenames', False):
+            payload["tag_using_filenames"] = False
+        if keywords.get('preserve_dirs', True):
+            payload["preserve_dirs"] = True
         # upload options
         if keywords.get('file_url', None) is not None:
             payload['upload_option'] = 'upload_file'
@@ -436,7 +440,7 @@ class LibraryClient(Client):
 
     def upload_file_from_server(self, library_id, server_dir, folder_id=None,
                                 file_type='auto', dbkey='?', link_data_only=None,
-                                roles=""):
+                                roles="", preserve_dirs=False, tag_using_filenames=True):
         """
         Upload all files in the specified subdirectory of the Galaxy library
         import directory to a library.
@@ -472,15 +476,22 @@ class LibraryClient(Client):
 
         :type roles: str
         :param roles: ???
+
+        :type preserve_dirs: bool
+        :param preserve_dirs: Indicate whether to preserve the directory structure when importing dir
+
+        :type tag_using_filenames: bool
+        :param tag_using_filenames: Indicate whether to generate dataset tags from filenames
         """
         return self._do_upload(library_id, server_dir=server_dir,
                                folder_id=folder_id, file_type=file_type,
                                dbkey=dbkey, link_data_only=link_data_only,
-                               roles=roles)
+                               roles=roles, preserve_dirs=preserve_dirs,
+                               tag_using_filenames=tag_using_filenames)
 
     def upload_from_galaxy_filesystem(self, library_id, filesystem_paths, folder_id=None,
                                       file_type="auto", dbkey="?", link_data_only=None,
-                                      roles=""):
+                                      roles="", preserve_dirs=False, tag_using_filenames=True):
         """
         Upload a set of files already present on the filesystem of the Galaxy
         server to a library.
@@ -515,11 +526,18 @@ class LibraryClient(Client):
 
         :type roles: str
         :param roles: ???
+
+        :type preserve_dirs: bool
+        :param preserve_dirs: Indicate whether to preserve the directory structure when importing dir
+
+        :type tag_using_filenames: bool
+        :param tag_using_filenames: Indicate whether to generate dataset tags from filenames
         """
         return self._do_upload(library_id, filesystem_paths=filesystem_paths,
                                folder_id=folder_id, file_type=file_type,
                                dbkey=dbkey, link_data_only=link_data_only,
-                               roles=roles)
+                               roles=roles, preserve_dirs=preserve_dirs,
+                               tag_using_filenames=tag_using_filenames)
 
     def copy_from_dataset(self, library_id, dataset_id, folder_id=None, message=''):
         """

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -335,10 +335,8 @@ class LibraryClient(Client):
             payload["roles"] = keywords["roles"]
         if keywords.get("link_data_only", None) and keywords['link_data_only'] != 'copy_files':
             payload["link_data_only"] = 'link_to_files'
-        if keywords.get('tag_using_filenames', False):
-            payload["tag_using_filenames"] = False
-        if keywords.get('preserve_dirs', True):
-            payload["preserve_dirs"] = True
+        payload['tag_using_filenames'] = str(keywords.get('tag_using_filenames', True))
+        payload['preserve_dirs'] = str(keywords.get('preserve_dirs', False))
         # upload options
         if keywords.get('file_url', None) is not None:
             payload['upload_option'] = 'upload_file'

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -120,7 +120,7 @@ class LibraryClient(Client):
         :return: details of the updated dataset
         """
         url = '/'.join([self.gi._make_url(self), 'datasets', dataset_id])
-        return self._put(payload=kwds, url=url)
+        return self._patch(payload=kwds, url=url)
 
     def show_dataset(self, library_id, dataset_id):
         """

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -96,13 +96,10 @@ class LibraryClient(Client):
         url = '/'.join([url, dataset_id])
         return self._delete(payload={'purged': purged}, url=url)
 
-    def update_library_dataset(self, library_id, dataset_id, **kwds):
+    def update_library_dataset(self, dataset_id, **kwds):
         """
         Update library dataset metadata. Some of the attributes that can be
         modified are documented below.
-
-        :type library_id: str
-        :param library_id: library id where dataset is found in
 
         :type dataset_id: str
         :param dataset_id: id of the dataset to be deleted
@@ -122,9 +119,7 @@ class LibraryClient(Client):
         :rtype: dict
         :return: details of the updated dataset
         """
-        url = self.gi._make_url(self, library_id, contents=True)
-        # Append the dataset_id to the base history contents URL
-        url = '/'.join([url, dataset_id])
+        url = '/'.join([self.gi._make_url(self), 'datasets', dataset_id])
         return self._put(payload=kwds, url=url)
 
     def show_dataset(self, library_id, dataset_id):

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -96,6 +96,37 @@ class LibraryClient(Client):
         url = '/'.join([url, dataset_id])
         return self._delete(payload={'purged': purged}, url=url)
 
+    def update_library_dataset(self, library_id, dataset_id, **kwds):
+        """
+        Update library dataset metadata. Some of the attributes that can be
+        modified are documented below.
+
+        :type library_id: str
+        :param library_id: library id where dataset is found in
+
+        :type dataset_id: str
+        :param dataset_id: id of the dataset to be deleted
+
+        :type name: str
+        :param name: Replace library dataset name with the given string
+
+        :type misc_info: str
+        :param misc_info: Replace library dataset misc_info with given string
+
+        :type file_ext: str
+        :param file_ext: Replace library dataset extension (must exist in the Galaxy registry)
+
+        :type genome_build: str
+        :param genome_build: Replace library dataset genome build (dbkey)
+
+        :rtype: dict
+        :return: details of the updated dataset
+        """
+        url = self.gi._make_url(self, library_id, contents=True)
+        # Append the dataset_id to the base history contents URL
+        url = '/'.join([url, dataset_id])
+        return self._put(payload=kwds, url=url)
+
     def show_dataset(self, library_id, dataset_id):
         """
         Get details about a given library dataset. The required ``library_id``

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -777,8 +777,7 @@ class LibraryDataset(LibRelatedDataset):
         :type genome_build: str
         :param genome_build: Replace history dataset genome build (dbkey)
         """
-        res = self.gi.gi.libraries.update_library_dataset(
-            self.container.id, self.id, **kwds)
+        res = self.gi.gi.libraries.update_library_dataset(self.id, **kwds)
         self.container.refresh()
         self.__init__(res, self.container, gi=self.gi)
         return self

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -493,7 +493,7 @@ class Dataset(Wrapper):
     Abstract base class for Galaxy datasets.
     """
     BASE_ATTRS = Wrapper.BASE_ATTRS + (
-        'data_type', 'file_name', 'file_size', 'state', 'deleted', 'file_ext', 'purged'
+        'data_type', 'file_ext', 'file_name', 'file_size', 'genome_build', 'misc_info', 'state'
     )
     POLLING_INTERVAL = 1  # for state monitoring
 
@@ -603,7 +603,7 @@ class HistoryDatasetAssociation(Dataset):
     """
     Maps to a Galaxy ``HistoryDatasetAssociation``.
     """
-    BASE_ATTRS = Dataset.BASE_ATTRS + ('annotation', 'genome_build', 'tags', 'visible')
+    BASE_ATTRS = Dataset.BASE_ATTRS + ('annotation', 'deleted', 'purged', 'tags', 'visible')
     SRC = 'hda'
 
     def __init__(self, ds_dict, container, gi=None):
@@ -745,6 +745,7 @@ class LibraryDatasetDatasetAssociation(LibRelatedDataset):
     """
     Maps to a Galaxy ``LibraryDatasetDatasetAssociation``.
     """
+    BASE_ATTRS = LibRelatedDataset.BASE_ATTRS + ('deleted',)
     SRC = 'ldda'
 
 

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -781,6 +781,7 @@ class LibraryDataset(LibRelatedDataset):
             self.container.id, self.id, **kwds)
         self.container.refresh()
         self.__init__(res, self.container, gi=self.gi)
+        return self
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -766,6 +766,22 @@ class LibraryDataset(LibRelatedDataset):
         self.container.refresh()
         self.refresh()
 
+    def update(self, **kwds):
+        """
+        Update this library dataset metadata. Some of the attributes that can be
+        modified are documented below.
+
+        :type name: str
+        :param name: Replace history dataset name with the given string
+
+        :type genome_build: str
+        :param genome_build: Replace history dataset genome build (dbkey)
+        """
+        res = self.gi.gi.libraries.update_library_dataset(
+            self.container.id, self.id, **kwds)
+        self.container.refresh()
+        self.__init__(res, self.container, gi=self.gi)
+
 
 @six.add_metaclass(abc.ABCMeta)
 class ContentInfo(Wrapper):

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -198,6 +198,33 @@ class GalaxyClient(object):
         raise ConnectionError("Unexpected HTTP status code: %s" % r.status_code,
                               body=r.text, status_code=r.status_code)
 
+    def make_patch_request(self, url, payload=None, params=None):
+        """
+        Make a PATCH request using the provided ``url`` with required payload.
+        The ``payload`` must be a dict that can be converted into a JSON
+        object (via ``json.dumps``).
+
+        :return: The decoded response.
+        """
+        if params is not None and params.get('key', False) is False:
+            params['key'] = self.key
+        else:
+            params = self.default_params
+
+        payload = json.dumps(payload)
+        headers = self.json_headers
+        r = requests.patch(url, data=payload, params=params, headers=headers,
+                           verify=self.verify, timeout=self.timeout)
+        if r.status_code == 200:
+            try:
+                return r.json()
+            except Exception as e:
+                raise ConnectionError("Request was successful, but cannot decode the response content: %s" %
+                                      e, body=r.content, status_code=r.status_code)
+        # @see self.body for HTTP response body
+        raise ConnectionError("Unexpected HTTP status code: %s" % r.status_code,
+                              body=r.text, status_code=r.status_code)
+
     @property
     def key(self):
         if not self._key and self.email is not None and self.password is not None:


### PR DESCRIPTION
Hi,
Here's a little update to the data library api:
- add library dataset update method
- add `preserve_dirs` and `tag_using_filenames` arguments when loading data into a data library
