### PR TITLE
fixed library retrieval behavior to reflect documentation, added tests

### DIFF
--- a/bioblend/_tests/TestGalaxyLibraries.py
+++ b/bioblend/_tests/TestGalaxyLibraries.py
@@ -12,7 +12,10 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
     def setUp(self):
         super(TestGalaxyLibraries, self).setUp()
         self.name = 'automated test library'
+        self.deleted_name = 'deleted test library'
         self.library = self.gi.libraries.create_library(self.name, description='automated test', synopsis='automated test synopsis')
+        self.deleted_library = self.gi.libraries.create_library(self.deleted_name, description='a deleted library', synopsis='automated test synopsis')
+        self.gi.libraries.delete_library(self.deleted_library['id'])
 
     def tearDown(self):
         self.gi.libraries.delete_library(self.library['id'])
@@ -23,8 +26,15 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
 
     def test_get_libraries(self):
         # Make sure there's at least one value - the one we created
-        all_libraries = self.gi.libraries.get_libraries()
-        self.assertGreaterEqual(len(all_libraries), 1)
+        # deleted = False -> default
+        all_libraries = self.gi.libraries.get_libraries(deleted=None) # all
+        deleted_libraries = self.gi.libraries.get_libraries(deleted=True, library_id=self.deleted_library['id'])
+        viable_libraries = self.gi.libraries.get_libraries(deleted=False, library_id=self.library['id'])
+        self.assertEqual(len(deleted_libraries), 1)
+        self.assertTrue(deleted_libraries[0]['name'] == self.deleted_name)
+        self.assertEqual(len(viable_libraries), 1)
+        self.assertTrue(viable_libraries[0]['name'] == self.name)
+        self.assertGreaterEqual(len(all_libraries), 2)
 
     def test_show_library(self):
         library_data = self.gi.libraries.show_library(self.library['id'])

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -286,7 +286,7 @@ class LibraryClient(Client):
         """
         if library_id is not None and name is not None:
             raise ValueError('Provide only one argument between name or library_id, but not both')
-        libraries = self._get(deleted=deleted)
+        libraries = self._get(params={"deleted":deleted})
         if library_id is not None:
             library = next((_ for _ in libraries if _['id'] == library_id), None)
             libraries = [library] if library is not None else []


### PR DESCRIPTION
I encountered the issue mentioned in #239: the `deleted` flag for get_libraries() was not being properly handled.

the code [in libraries/get_libraries()](https://github.com/galaxyproject/bioblend/blob/c5059e550c54de7fd60a90a48bb627918e42eca7/bioblend/galaxy/libraries/__init__.py#L267) sets a `deleted` flag for `self._get()`, which [attempts to make the url with or without `deleted` as part of the URI path](https://github.com/galaxyproject/bioblend/blob/c5059e550c54de7fd60a90a48bb627918e42eca7/bioblend/galaxyclient.py#L68), not a URI parameter. however, in the case where deleted is False, this URI path component is not included, which gives all libraries including deleted libraries. That should only happen when deleted is set to None.

These changes send `deleted` as a parameter, which [is caught further in the `self._get()` method](https://github.com/galaxyproject/bioblend/blob/c5059e550c54de7fd60a90a48bb627918e42eca7/bioblend/galaxy/client.py#L107), and correctly returns the requested values.

- deleted = False -> does not include deleted
- deleted = True -> only includes deleted
- deleted = None -> includes both

the added tests verify this functionality.