### PR TITLE
Explains how to work with <repeat /> parameters

### DIFF
--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -450,7 +450,7 @@ class WorkflowClient(Client):
           "cutoff_1|min": "4",
           "cutoff_1|max": "19000.0",
           
-        as the time of this writing, the ability to set the second parameter (or the n-th) is limited by the workflow
+        At the time of this writing, the ability to set the second parameter (or the n-th) is limited by the workflow
         provided in the invoke call to have been added at least 2 parameters before being exported in the UI. If the UI,
         at the moment of exporting the workflow, only had one parameter of the repeat set there, then only the first element
         above ("n_genes") will be set succesfully on calling ``invoke_workflow``.

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -429,6 +429,31 @@ class WorkflowClient(Client):
           {'param': PARAM_NAME, 'value': VALUE}
 
         Note that this format allows only one parameter to be set per step.
+        
+        Note that for a repeat parameter configured in the tool xml like::
+        
+          <repeat name="cutoff" title="Parameters used to filter cells" min="1">
+            <param name="name" type="text" value="n_genes" label="Name of param...">
+              <option value="n_genes">n_genes</option>
+              <option value="n_counts">n_counts</option>
+            </param>
+            <param name="min" type="float" value="0" min="0" label="Min value"/>
+            <param name="max" type="float" value="1e9" label="Max value"/>
+          </repeat>
+          
+        the content of the parameter dictionary for that step needs to follow this syntax::
+        
+          "cutoff_0|name": "n_genes",
+          "cutoff_0|min": "2",
+          "cutoff_0|max": "1000.0",
+          "cutoff_1|name": "n_counts",
+          "cutoff_1|min": "4",
+          "cutoff_1|max": "19000.0",
+          
+        as the time of this writing, the ability to set the second parameter (or the n-th) is limited by the workflow
+        provided in the invoke call to have been added at least 2 parameters before being exported in the UI. If the UI,
+        at the moment of exporting the workflow, only had one parameter of the repeat set there, then only the first element
+        above ("n_genes") will be set succesfully on calling ``invoke_workflow``.
 
         The ``replacement_params`` dict should map parameter names in
         post-job actions (PJAs) to their runtime values. For

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -430,7 +430,7 @@ class WorkflowClient(Client):
 
         Note that this format allows only one parameter to be set per step.
         
-        Note that for a repeat parameter configured in the tool xml like::
+        Note that for a repeat parameter configured in the tool XML like::
         
           <repeat name="cutoff" title="Parameters used to filter cells" min="1">
             <param name="name" type="text" value="n_genes" label="Name of param...">

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -456,7 +456,7 @@ class WorkflowClient(Client):
         At the time of this writing, it is not possible to change the number of
         times the contained parameters are repeated. Therefore, the parameter
         indexes can go from 0 to n-1, where n is the number of times the
-        repeated element was added when the workflow was saved.
+        repeated element was added when the workflow was saved in the Galaxy UI.
 
         The ``replacement_params`` dict should map parameter names in
         post-job actions (PJAs) to their runtime values. For

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -453,7 +453,7 @@ class WorkflowClient(Client):
         At the time of this writing, the ability to set the second parameter (or the n-th) is limited by the workflow
         provided in the invoke call to have been added at least 2 parameters before being exported in the UI. If the UI,
         at the moment of exporting the workflow, only had one parameter of the repeat set there, then only the first element
-        above ("n_genes") will be set succesfully on calling ``invoke_workflow``.
+        above ("n_genes") will be set successfully when calling ``invoke_workflow``.
 
         The ``replacement_params`` dict should map parameter names in
         post-job actions (PJAs) to their runtime values. For

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -430,7 +430,9 @@ class WorkflowClient(Client):
 
         Note that this format allows only one parameter to be set per step.
 
-        Note that for a repeat parameter configured in the tool XML like::
+        For a ``repeat`` parameter, the names of the contained parameters needs
+        to be specified as ``<repeat name>_<repeat index>|<param name>``, with
+        the repeat index starting at 0. For example, if the tool XML contains::
 
           <repeat name="cutoff" title="Parameters used to filter cells" min="1">
             <param name="name" type="text" value="n_genes" label="Name of param...">
@@ -438,26 +440,23 @@ class WorkflowClient(Client):
               <option value="n_counts">n_counts</option>
             </param>
             <param name="min" type="float" value="0" min="0" label="Min value"/>
-            <param name="max" type="float" value="1e9" label="Max value"/>
           </repeat>
 
-        the content of the parameter dictionary for that step needs to follow this syntax::
+        then the PARAM_DICT should be something like::
 
-          "step_id": {
+          {
             ...
             "cutoff_0|name": "n_genes",
             "cutoff_0|min": "2",
-            "cutoff_0|max": "1000.0",
             "cutoff_1|name": "n_counts",
             "cutoff_1|min": "4",
-            "cutoff_1|max": "19000.0",
             ...
           }
 
-        At the time of this writing, the ability to set the second parameter (or the n-th) is limited by the workflow
-        provided in the invoke call to have been added at least 2 parameters before being exported in the UI. If the UI,
-        at the moment of exporting the workflow, only had one parameter of the repeat set there, then only the first element
-        above ("n_genes") will be set successfully when calling ``invoke_workflow``.
+        At the time of this writing, it is not possible to change the number of
+        times the contained parameters are repeated. Therefore, the parameter
+        indexes can go from 0 to n-1, where n is the number of times the
+        repeated element was added when the workflow was saved.
 
         The ``replacement_params`` dict should map parameter names in
         post-job actions (PJAs) to their runtime values. For

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -429,9 +429,9 @@ class WorkflowClient(Client):
           {'param': PARAM_NAME, 'value': VALUE}
 
         Note that this format allows only one parameter to be set per step.
-        
+
         Note that for a repeat parameter configured in the tool XML like::
-        
+
           <repeat name="cutoff" title="Parameters used to filter cells" min="1">
             <param name="name" type="text" value="n_genes" label="Name of param...">
               <option value="n_genes">n_genes</option>
@@ -440,16 +440,20 @@ class WorkflowClient(Client):
             <param name="min" type="float" value="0" min="0" label="Min value"/>
             <param name="max" type="float" value="1e9" label="Max value"/>
           </repeat>
-          
+
         the content of the parameter dictionary for that step needs to follow this syntax::
-        
-          "cutoff_0|name": "n_genes",
-          "cutoff_0|min": "2",
-          "cutoff_0|max": "1000.0",
-          "cutoff_1|name": "n_counts",
-          "cutoff_1|min": "4",
-          "cutoff_1|max": "19000.0",
-          
+
+          "step_id": {
+            ...
+            "cutoff_0|name": "n_genes",
+            "cutoff_0|min": "2",
+            "cutoff_0|max": "1000.0",
+            "cutoff_1|name": "n_counts",
+            "cutoff_1|min": "4",
+            "cutoff_1|max": "19000.0",
+            ...
+          }
+
         At the time of this writing, the ability to set the second parameter (or the n-th) is limited by the workflow
         provided in the invoke call to have been added at least 2 parameters before being exported in the UI. If the UI,
         at the moment of exporting the workflow, only had one parameter of the repeat set there, then only the first element


### PR DESCRIPTION
Using repeat parameters is quite tricky, and is not made explicit anywhere but in Galaxy API tests.