### PR TITLE
make range in wait_for_dataset use int

### DIFF
--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -168,7 +168,7 @@ class LibraryClient(Client):
         assert maxwait > 0
         assert interval > 0
 
-        for time_left in range(maxwait, 0, -interval):
+        for time_left in range(int(maxwait), 0, int(-interval)):
             dataset = self.show_dataset(library_id, dataset_id)
             state = dataset['state']
             if state in terminal_states:


### PR DESCRIPTION
The signature of `wait_for_dataset` in the `libraries` module suggests the `maxwait` and `interval` parameters are of type float. These are then used in a `range()` function which expects `int` types, thus triggering an error. This patch forces them to integers.