### PR TITLE
Fix error with toolshed get_ordered_installable_revisions and get_repository_revision_install_info

### DIFF
--- a/bioblend/toolshed/repositories/__init__.py
+++ b/bioblend/toolshed/repositories/__init__.py
@@ -222,7 +222,7 @@ class ToolShedRepositoryClient(Client):
                                                  'type': 'package',
                                                  'version': '0.1.18'}}]}]
         """
-        url = self.gi.url + '/repositories/get_repository_revision_install_info'
+        url = self._make_url() + '/get_repository_revision_install_info'
         params = {
             'name': name,
             'owner': owner,

--- a/bioblend/toolshed/repositories/__init__.py
+++ b/bioblend/toolshed/repositories/__init__.py
@@ -141,7 +141,7 @@ class ToolShedRepositoryClient(Client):
         :rtype: list
         :return: List of changeset revision hash strings from oldest to newest
         """
-        url = self.url + '/get_ordered_installable_revisions'
+        url = self.gi.url + '/repositories/get_ordered_installable_revisions'
         params = {
             'name': name,
             'owner': owner
@@ -222,7 +222,7 @@ class ToolShedRepositoryClient(Client):
                                                  'type': 'package',
                                                  'version': '0.1.18'}}]}]
         """
-        url = self.url + '/get_repository_revision_install_info'
+        url = self.gi.url + '/repositories/get_repository_revision_install_info'
         params = {
             'name': name,
             'owner': owner,

--- a/bioblend/toolshed/repositories/__init__.py
+++ b/bioblend/toolshed/repositories/__init__.py
@@ -141,7 +141,7 @@ class ToolShedRepositoryClient(Client):
         :rtype: list
         :return: List of changeset revision hash strings from oldest to newest
         """
-        url = self.gi.url + '/repositories/get_ordered_installable_revisions'
+        url = self._make_url() + '/get_ordered_installable_revisions'
         params = {
             'name': name,
             'owner': owner


### PR DESCRIPTION
This fixes the following error I get when trying to get the list of revisions for a tool from the toolshed:
```
  File "/home/abretaud/miniconda3/lib/python3.7/site-packages/bioblend/toolshed/repositories/__init__.py", line 144, in get_ordered_installable_revisions
    url = self.url + '/get_ordered_installable_revisions'
AttributeError: 'ToolShedRepositoryClient' object has no attribute 'url'
```

What surprises me is that this usegalaxy.eu script should be failing without this patch, but somehow tools get updated: https://github.com/usegalaxy-eu/usegalaxy-eu-tools/blob/master/scripts/update-tool.py#L35