### PR TITLE
Add get_datasets() function

### DIFF
--- a/bioblend/_tests/TestGalaxyDatasets.py
+++ b/bioblend/_tests/TestGalaxyDatasets.py
@@ -50,6 +50,7 @@ class TestGalaxyDatasets(GalaxyTestBase.GalaxyTestBase):
             f.flush()
             self.assertEqual(f.read(), expected_contents)
 
+    @test_util.skip_unless_galaxy('release_19.05')
     def test_get_datasets(self):
         datasets = self.gi.datasets.get_datasets()
         dataset_ids = [dataset['id'] for dataset in datasets]

--- a/bioblend/_tests/TestGalaxyDatasets.py
+++ b/bioblend/_tests/TestGalaxyDatasets.py
@@ -49,3 +49,10 @@ class TestGalaxyDatasets(GalaxyTestBase.GalaxyTestBase):
             self.assertEqual(download_filename, f.name)
             f.flush()
             self.assertEqual(f.read(), expected_contents)
+
+    def test_get_datasets(self):
+        datasets = self.gi.datasets.get_datasets()
+        dataset_ids = [dataset['id'] for dataset in datasets]
+        assert self.dataset_id in dataset_ids
+        datasets = self.gi.datasets.get_datasets(limit=0)
+        assert datasets == []

--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -139,7 +139,7 @@ class DatasetClient(Client):
         :rtype: list
         :return: Return a list of dataset dicts.
         """
-        url = urljoin(self.gi._make_url(self), '?limit={}&offset={}'.format(limit, offset))
+        url = urljoin(self._make_url(), '?limit={}&offset={}'.format(limit, offset))
         return self._get(url=url)
 
     def _block_until_dataset_terminal(self, dataset_id, maxwait=12000, interval=3):

--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -134,8 +134,8 @@ class DatasetClient(Client):
         :param limit: Maximum number of datasets to return.
 
         :type offset: int
-        :param offset: Return datasets starting from this specified position. For example
-                       if limit is set to 100 and offset to 200, datasets 200 - 300 will be returned
+        :param offset: Return datasets starting from this specified position. For example,
+                       if ``limit`` is set to 100 and ``offset`` to 200, datasets 200 - 300 will be returned.
         :rtype: list
         :return: Return a list of dataset dicts.
         """

--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -127,20 +127,25 @@ class DatasetClient(Client):
 
     def get_datasets(self, limit=500, offset=0):
         """
-        Provide a list of all datasets. Note this may be very large, so ``limit`` and ``offset``
-        parameters may be specified.
+        Provide a list of all datasets. Since this may be very large, ``limit``
+        and ``offset`` parameters should be used to speficy the desired range.
 
         :type limit: int
         :param limit: Maximum number of datasets to return.
 
         :type offset: int
-        :param offset: Return datasets starting from this specified position. For example,
-                       if ``limit`` is set to 100 and ``offset`` to 200, datasets 200 - 300 will be returned.
+        :param offset: Return datasets starting from this specified position.
+          For example, if ``limit`` is set to 100 and ``offset`` to 200,
+          datasets 200-299 will be returned.
+
         :rtype: list
         :return: Return a list of dataset dicts.
         """
-        url = urljoin(self._make_url(), '?limit={}&offset={}'.format(limit, offset))
-        return self._get(url=url)
+        params = {
+            'limit': limit,
+            'offset': offset,
+        }
+        return self._get(params=params)
 
     def _block_until_dataset_terminal(self, dataset_id, maxwait=12000, interval=3):
         """

--- a/bioblend/galaxy/datasets/__init__.py
+++ b/bioblend/galaxy/datasets/__init__.py
@@ -125,6 +125,23 @@ class DatasetClient(Client):
             # Return location file was saved to
             return file_local_path
 
+    def get_datasets(self, limit=500, offset=0):
+        """
+        Provide a list of all datasets. Note this may be very large, so ``limit`` and ``offset``
+        parameters may be specified.
+
+        :type limit: int
+        :param limit: Maximum number of datasets to return.
+
+        :type offset: int
+        :param offset: Return datasets starting from this specified position. For example
+                       if limit is set to 100 and offset to 200, datasets 200 - 300 will be returned
+        :rtype: list
+        :return: Return a list of dataset dicts.
+        """
+        url = urljoin(self.gi._make_url(self), '?limit={}&offset={}'.format(limit, offset))
+        return self._get(url=url)
+
     def _block_until_dataset_terminal(self, dataset_id, maxwait=12000, interval=3):
         """
         Wait until the dataset state is terminal ('ok', 'empty', 'error',


### PR DESCRIPTION
Add function to access `/api/datasets` to get a list of all datasets, with `limit` and `offset` parameters.