### PR TITLE
Fix TravisCI. Drop support for Galaxy <=17.05

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
             - python3.6-dev
     - stage: test
       os: osx
-      # No version of Python is available via language: on OS X workers, see https://github.com/travis-ci/travis-ci/issues/2312
+      # Selection of Python version is not available via language: on OS X workers, see https://github.com/travis-ci/travis-ci/issues/2312
       language: generic
       env: TOX_ENV=py37 GALAXY_VERSION=dev
       before_install:
@@ -75,10 +75,6 @@ matrix:
         - initdb /usr/local/var/postgres
         - pg_ctl -D /usr/local/var/postgres start
         - createuser -s postgres
-        # virtualenv has not been installed on OS X workers any more since xcode9.4 became the default image, see https://github.com/travis-ci/travis-ci/issues/9966
-        - python3 -m pip install --upgrade virtualenv
-        - virtualenv -p python3 .venv
-        - . .venv/bin/activate
 
     - stage: deploy
       python: '3.6'
@@ -100,8 +96,8 @@ before_install:
   - sudo rm -f /etc/boto.cfg
 
 install:
-  # Here Python is v 2.7 for lint and 3 for test stage
-  - python -m pip install "tox>=1.8.0"
+  # Need virtualenv 20.0.14 for https://github.com/pypa/virtualenv/pull/1749
+  - python -m pip install 'tox>=1.8.0' 'virtualenv>=20.0.14'
 
 before_script:
   # Create a PostgreSQL database for Galaxy. The default SQLite3 database makes test fail randomly because of "database locked" error.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 python: "2.7"
 services:
@@ -11,32 +11,23 @@ stages:
     if: tag IS present
 
 env:
-  - TOX_ENV=py35 GALAXY_VERSION=dev
-  - TOX_ENV=py35 GALAXY_VERSION=release_20.01
-  - TOX_ENV=py35 GALAXY_VERSION=release_19.09
-  - TOX_ENV=py35 GALAXY_VERSION=release_19.05
-  - TOX_ENV=py35 GALAXY_VERSION=release_19.01
-  - TOX_ENV=py35 GALAXY_VERSION=release_18.09
-  - TOX_ENV=py35 GALAXY_VERSION=release_18.05
-  - TOX_ENV=py35 GALAXY_VERSION=release_18.01
-  - TOX_ENV=py35 GALAXY_VERSION=release_17.09
-  - TOX_ENV=py35 GALAXY_VERSION=release_17.05
-  - TOX_ENV=py35 GALAXY_VERSION=release_17.01
-  - TOX_ENV=py35 GALAXY_VERSION=release_16.10
-  - TOX_ENV=py35 GALAXY_VERSION=release_16.07
-  - TOX_ENV=py35 GALAXY_VERSION=release_16.04
-  - TOX_ENV=py35 GALAXY_VERSION=release_16.01
-  - TOX_ENV=py35 GALAXY_VERSION=release_15.10
-  - TOX_ENV=py35 GALAXY_VERSION=release_15.07
-  - TOX_ENV=py35 GALAXY_VERSION=release_15.05
-  - TOX_ENV=py35 GALAXY_VERSION=release_15.03
+  - TOX_ENV=py36 GALAXY_VERSION=dev
+  - TOX_ENV=py36 GALAXY_VERSION=release_20.01
+  - TOX_ENV=py36 GALAXY_VERSION=release_19.09
+  - TOX_ENV=py36 GALAXY_VERSION=release_19.05
+  - TOX_ENV=py36 GALAXY_VERSION=release_19.01
+  - TOX_ENV=py36 GALAXY_VERSION=release_18.09
+  - TOX_ENV=py36 GALAXY_VERSION=release_18.05
+  - TOX_ENV=py36 GALAXY_VERSION=release_18.01
+  - TOX_ENV=py36 GALAXY_VERSION=release_17.09
 
 matrix:
   include:
     - stage: lint
+      env: []
       python: '3.5'
-      before_install: {}
-      before_script: {}
+      before_install: []
+      before_script: []
       script: tox -e flake8
 
     - stage: test
@@ -47,7 +38,6 @@ matrix:
             - deadsnakes
           packages:
             - python3.8-dev
-            - python3.8-distutils
     - stage: test
       env: TOX_ENV=py37 GALAXY_VERSION=dev
       addons:
@@ -57,13 +47,13 @@ matrix:
           packages:
             - python3.7-dev
     - stage: test
-      env: TOX_ENV=py36 GALAXY_VERSION=dev
+      env: TOX_ENV=py35 GALAXY_VERSION=dev
       addons:
         apt:
           sources:
             - deadsnakes
           packages:
-            - python3.6-dev
+            - python3.5-dev
     - stage: test
       os: osx
       # Selection of Python version is not available via language: on OS X workers, see https://github.com/travis-ci/travis-ci/issues/2312
@@ -77,15 +67,15 @@ matrix:
         - createuser -s postgres
 
     - stage: deploy
-      python: '3.6'
+      python: '3.7'
       env:
         - TWINE_USERNAME=__token__
         # TWINE_PASSWORD environment variable is saved in Travis CI Settings
-      before_install: {}
+      before_install: []
       install:
         - python3 -m pip install --upgrade pip setuptools
         - python3 -m pip install --upgrade twine wheel
-      before_script: {}
+      before_script: []
       script:
         - python3 setup.py sdist bdist_wheel
         - twine check dist/*
@@ -115,10 +105,10 @@ before_script:
   - export BIOBLEND_GALAXY_USER_EMAIL=${USER}@localhost.localdomain
   - DATABASE_CONNECTION=postgresql://postgres:@localhost/galaxy-travis
   - eval "echo \"$(cat "${TRAVIS_BUILD_DIR}/tests/template_galaxy.ini")\"" > "$GALAXY_CONFIG_FILE"
-  # Update kombu requirement (and its dependency amqp) to a version compatible with Python 2.7.11, see https://github.com/celery/kombu/pull/540
+  # Update psycopg2 requirement to a version compatible with glibc 2.26 for Galaxy releases 16.01-18.01, see https://github.com/psycopg/psycopg2-wheels/issues/2
   - |
-    if [ -f eggs.ini ]; then
-      sed -i.bak -e 's/^kombu = .*$/kombu = 3.0.30/' -e 's/^amqp = .*$/amqp = 1.4.8/' eggs.ini;
+    if [ -f lib/galaxy/dependencies/conditional-requirements.txt ]; then
+      sed -i.bak -e 's/psycopg2==2.6.1/psycopg2==2.7.3.1/' lib/galaxy/dependencies/conditional-requirements.txt
     fi
   # Start Galaxy and wait for successful server start
   - export GALAXY_SKIP_CLIENT_BUILD=1

--- a/ABOUT.rst
+++ b/ABOUT.rst
@@ -4,7 +4,7 @@ interacting with `Galaxy`_ and `CloudMan`_  APIs.
 BioBlend is supported and tested on:
 
 - Python 3.5, 3.6, 3.7 and 3.8
-- Galaxy release_15.03 and later.
+- Galaxy release_17.09 and later.
 
 BioBlend's goal is to make it easier to script and automate the running of
 Galaxy analyses, administering of a Galaxy server, and cloud infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### BioBlend v0.14.0 - unreleased
 
-* Dropped support Python 2.7. Dropped support for Galaxy releases 14.10 and
-  15.01. Added support for Python 3.8. Added support for Galaxy releases 19.09
+* Dropped support Python 2.7. Dropped support for Galaxy releases 14.10-17.05.
+  Added support for Python 3.8. Added support for Galaxy releases 19.09
   and 20.01.
 
 * Removed deprecated ``show_stderr()`` and ``show_stdout`` methods of

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ APIs.
 BioBlend is supported and tested on:
 
 - Python 3.5, 3.6, 3.7 and 3.8
-- Galaxy release_15.03 and later.
+- Galaxy release_17.09 and later.
 
 Full docs are available at https://bioblend.readthedocs.io/ with a quick library
 overview also available in `ABOUT.rst <./ABOUT.rst>`_.

--- a/bioblend/_tests/TestGalaxyFolders.py
+++ b/bioblend/_tests/TestGalaxyFolders.py
@@ -1,4 +1,4 @@
-from . import GalaxyTestBase, test_util
+from . import GalaxyTestBase
 
 FOO_DATA = 'foo\nbar\n'
 
@@ -27,21 +27,17 @@ class TestGalaxyFolders(GalaxyTestBase.GalaxyTestBase):
         f2 = self.gi.folders.show_folder(self.folder['id'], contents=True)
         self.assertIn('folder_contents', f2)
         self.assertIn('metadata', f2)
-        # 'folder_name' key of metadata dict was added in release_16.01
-        if 'folder_name' in f2['metadata']:
-            self.assertEqual(self.name, f2['metadata']['folder_name'])
+        self.assertEqual(self.name, f2['metadata']['folder_name'])
 
     def test_delete_folder(self):
         self.sub_folder = self.gi.folders.create_folder(self.folder['id'], self.name)
         self.gi.folders.delete_folder(self.sub_folder['id'])
 
-    @test_util.skip_unless_galaxy("release_15.10")
     def test_update_folder(self):
         self.folder = self.gi.folders.update_folder(self.folder['id'], 'new-name', 'new-description')
         self.assertEqual(self.folder['name'], 'new-name')
         self.assertEqual(self.folder['description'], 'new-description')
 
-    @test_util.skip_unless_galaxy("release_16.01")
     def test_get_set_permissions(self):
         empty_permission = {'add_library_item_role_list': [], 'modify_folder_role_list': [], 'manage_folder_role_list': []}
         # They should be empty to start with

--- a/bioblend/_tests/TestGalaxyHistories.py
+++ b/bioblend/_tests/TestGalaxyHistories.py
@@ -120,13 +120,11 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
         self.assertTrue(dataset["deleted"])
         self.assertFalse(dataset['purged'])
 
-    @test_util.skip_unless_galaxy("release_17.05")
     def test_purge_dataset(self):
         history_id = self.history["id"]
         dataset1_id = self._test_dataset(history_id)
         self.gi.histories.delete_dataset(history_id, dataset1_id, purge=True)
         dataset = self.gi.histories.show_dataset(history_id, dataset1_id)
-        # Galaxy from release_15.03 to release_17.01 wrongly reports dataset["deleted"] as False, see https://github.com/galaxyproject/galaxy/issues/3548
         self.assertTrue(dataset["deleted"])
         self.assertTrue(dataset['purged'])
 

--- a/bioblend/_tests/TestGalaxyLibraries.py
+++ b/bioblend/_tests/TestGalaxyLibraries.py
@@ -84,7 +84,6 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
         dataset_id = self._test_dataset(history['id'])
         self.gi.libraries.copy_from_dataset(self.library['id'], dataset_id, message='Copied from dataset')
 
-    @test_util.skip_unless_galaxy('release_17.09')
     def test_update_dataset(self):
         library_id = self.library["id"]
         dataset1 = self.gi.libraries.upload_file_contents(library_id, FOO_DATA)
@@ -102,7 +101,6 @@ class TestGalaxyLibraries(GalaxyTestBase.GalaxyTestBase):
         self.assertEqual(set(_[1] for _ in ret['add_library_item_role_list']), set(user_id_list_new))
         self.assertEqual(set(_[1] for _ in ret['manage_library_role_list']), set(user_id_list_new))
 
-    @test_util.skip_unless_galaxy('release_16.04')
     def test_dataset_permissions(self):
         current_user = self.gi.users.get_current_user()
         user_id_list_new = [current_user['id']]

--- a/bioblend/_tests/TestGalaxyObjects.py
+++ b/bioblend/_tests/TestGalaxyObjects.py
@@ -539,7 +539,6 @@ class TestLDContents(GalaxyObjectsTestBase):
         # by the API at the moment
         # self.assertTrue(self.ds.deleted)
 
-    @test_util.skip_unless_galaxy('release_17.09')
     def test_dataset_update(self):
         new_name = 'test_%s' % uuid.uuid4().hex
         new_misc_info = 'Annotation for %s' % new_name
@@ -710,10 +709,8 @@ class TestHDAContents(GalaxyObjectsTestBase):
         self.assertTrue(self.ds.deleted)
         self.assertFalse(self.ds.purged)
 
-    @test_util.skip_unless_galaxy("release_17.05")
     def test_dataset_purge(self):
         self.ds.delete(purge=True)
-        # Galaxy from release_15.03 to release_17.01 wrongly reports ds.deleted as False, see https://github.com/galaxyproject/galaxy/issues/3548
         self.assertTrue(self.ds.deleted)
         self.assertTrue(self.ds.purged)
 

--- a/bioblend/_tests/TestGalaxyTools.py
+++ b/bioblend/_tests/TestGalaxyTools.py
@@ -130,8 +130,6 @@ class TestGalaxyTools(GalaxyTestBase.GalaxyTestBase):
         # TODO: Wait for results and verify it has 3 lines - 1 2 3, 4 5 6,
         # and 7 8 9.
 
-    # This test doesn't work any more on Galaxy 16.10 because that release uses an old Conda 3.19.3
-    @test_util.skip_unless_galaxy('release_17.01')
     def test_tool_dependency_install(self):
         installed_dependencies = self.gi.tools.install_dependencies('CONVERTER_fasta_to_bowtie_color_index')
         self.assertTrue(any(True for d in installed_dependencies if d.get('name') == 'bowtie' and d.get('dependency_type') == 'conda'), "installed_dependencies is %s" % installed_dependencies)

--- a/bioblend/_tests/TestGalaxyUsers.py
+++ b/bioblend/_tests/TestGalaxyUsers.py
@@ -2,7 +2,7 @@
 Tests the functionality of the Blend CloudMan API. These tests require working
 credentials to supported cloud infrastructure.
 """
-from . import GalaxyTestBase, test_util
+from . import GalaxyTestBase
 
 
 class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
@@ -23,7 +23,6 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
 #        self.assertEqual(user['nice_total_disk_usage'], current_user['nice_total_disk_usage'])
 #        self.assertEqual(user['total_disk_usage'], current_user['total_disk_usage'])
 
-    @test_util.skip_unless_galaxy('release_16.01')
     def test_create_remote_user(self):
         # WARNING: only admins can create users!
         # WARNING: Users cannot be purged through the Galaxy API, so execute
@@ -38,7 +37,6 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
             self.assertEqual(deleted_user['email'], new_user_email)
             self.assertTrue(deleted_user['deleted'])
 
-    @test_util.skip_unless_galaxy('release_16.01')
     def test_create_local_user(self):
         # WARNING: only admins can create users!
         # WARNING: Users cannot be purged through the Galaxy API, so execute
@@ -62,7 +60,6 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         self.assertIsNotNone(user['nice_total_disk_usage'])
         self.assertIsNotNone(user['total_disk_usage'])
 
-    @test_util.skip_unless_galaxy('release_17.01')
     def test_update_user(self):
         # WARNING: only admins can create users!
         # WARNING: Users cannot be purged through the Galaxy API, so execute

--- a/bioblend/_tests/TestGalaxyWorkflows.py
+++ b/bioblend/_tests/TestGalaxyWorkflows.py
@@ -9,7 +9,6 @@ from . import GalaxyTestBase, test_util
 
 class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
 
-    @test_util.skip_unless_galaxy('release_15.03')
     @test_util.skip_unless_tool("cat1")
     @test_util.skip_unless_tool("cat")
     def test_workflow_scheduling(self):
@@ -59,7 +58,6 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         invocation = self.gi.workflows.show_invocation(workflow_id, invocation_id)
         self.assertEqual(invocation["state"], "scheduled")
 
-    @test_util.skip_unless_galaxy('release_15.03')
     @test_util.skip_unless_tool("cat1")
     @test_util.skip_unless_tool("cat")
     def test_cancelling_workflow_scheduling(self):
@@ -94,9 +92,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
         imported_wf = self.gi.workflows.import_workflow_from_local_path(path)
         self.assertIsInstance(imported_wf, dict)
-        # Galaxy up to release_17.05 adds ' (imported from API)' to the
-        # imported workflow name
-        self.assertIn(imported_wf['name'], ('paste_columns', 'paste_columns (imported from API)'))
+        self.assertEqual(imported_wf['name'], 'paste_columns')
         self.assertTrue(imported_wf['url'].startswith('/api/workflows/'))
         self.assertFalse(imported_wf['deleted'])
         self.assertFalse(imported_wf['published'])
@@ -127,9 +123,7 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
             wf_dict = json.load(f)
         imported_wf = self.gi.workflows.import_workflow_dict(wf_dict)
         self.assertIsInstance(imported_wf, dict)
-        # Galaxy up to release_17.05 adds ' (imported from API)' to the
-        # imported workflow name
-        self.assertIn(imported_wf['name'], ('paste_columns', 'paste_columns (imported from API)'))
+        self.assertEqual(imported_wf['name'], 'paste_columns')
         self.assertTrue(imported_wf['url'].startswith('/api/workflows/'))
         self.assertFalse(imported_wf['deleted'])
         self.assertFalse(imported_wf['published'])
@@ -200,7 +194,6 @@ class TestGalaxyWorkflows(GalaxyTestBase.GalaxyTestBase):
         with self.assertRaises(Exception):
             self.gi.workflows.run_workflow(wf['id'], None)
 
-    @test_util.skip_unless_galaxy('release_15.03')
     def test_invoke_workflow(self):
         path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
         wf = self.gi.workflows.import_workflow_from_local_path(path)

--- a/bioblend/galaxy/config/__init__.py
+++ b/bioblend/galaxy/config/__init__.py
@@ -39,7 +39,6 @@ class ConfigClient(Client):
     def get_version(self):
         """
         Get the current version of the Galaxy instance.
-        This functionality is available since Galaxy ``release_15.03``.
 
         :rtype: dict
         :return: Version of the Galaxy instance

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -156,12 +156,6 @@ class HistoryClient(Client):
             For the purge option to work, the Galaxy instance must have the
             ``allow_user_dataset_purge`` option set to ``true`` in the
             ``config/galaxy.yml`` configuration file.
-
-        .. warning::
-            If you purge a dataset which has not been previously deleted,
-            Galaxy from release_15.03 to release_17.01 does not set the
-            ``deleted`` attribute of the dataset to ``True``, see
-            https://github.com/galaxyproject/galaxy/issues/3548
         """
         url = '/'.join((self._make_url(history_id, contents=True), dataset_id))
         payload = {}

--- a/bioblend/galaxy/libraries/__init__.py
+++ b/bioblend/galaxy/libraries/__init__.py
@@ -542,8 +542,7 @@ class LibraryClient(Client):
 
         .. note::
           For this method to work, the Galaxy instance must have the
-          ``allow_path_paste`` (``allow_library_path_paste`` in Galaxy
-          ``release_17.05`` and earlier) option set to ``true`` in the
+          ``allow_path_paste`` option set to ``true`` in the
           ``config/galaxy.yml`` configuration file.
 
         :type library_id: str

--- a/bioblend/galaxy/objects/wrappers.py
+++ b/bioblend/galaxy/objects/wrappers.py
@@ -170,15 +170,6 @@ class Step(Wrapper):
             raise ValueError('not a step dict')
         if stype not in {'data_collection_input', 'data_input', 'parameter_input', 'pause', 'subworkflow', 'tool'}:
             raise ValueError('Unknown step type: %r' % stype)
-        if self.type == 'tool' and self.tool_inputs:
-            for k, v in self.tool_inputs.items():
-                # In Galaxy before release_17.05, v is a JSON-encoded string
-                if not isinstance(v, str):
-                    break
-                try:
-                    self.tool_inputs[k] = json.loads(v)
-                except ValueError:
-                    break
 
     @property
     def gi_module(self):
@@ -661,12 +652,6 @@ class HistoryDatasetAssociation(Dataset):
             For the purge option to work, the Galaxy instance must have the
             ``allow_user_dataset_purge`` option set to ``true`` in the
             ``config/galaxy.yml`` configuration file.
-
-        .. warning::
-            If you purge a dataset which has not been previously deleted,
-            Galaxy from release_15.03 to release_17.01 does not set the
-            ``deleted`` attribute of the dataset to ``True``, see
-            https://github.com/galaxyproject/galaxy/issues/3548
         """
         self.gi.gi.histories.delete_dataset(self.container.id, self.id, purge=purge)
         self.container.refresh()
@@ -1195,8 +1180,7 @@ class Library(DatasetContainer):
 
         .. note::
           For this method to work, the Galaxy instance must have the
-          ``allow_path_paste`` (``allow_library_path_paste`` in Galaxy
-          ``release_17.05`` and earlier) option set to ``true`` in the
+          ``allow_path_paste`` option set to ``true`` in the
           ``config/galaxy.yml`` configuration file.
 
         :type paths: str or :class:`~collections.abc.Iterable` of str

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -69,8 +69,7 @@ class ToolClient(Client):
         """
         Install dependencies for a given tool via a resolver.
         This works only for Conda currently.
-        This functionality is available since Galaxy release_16.10
-        and is available only to Galaxy admins.
+        This functionality is available only to Galaxy admins.
 
         :type tool_id: str
         :param tool_id: id of the requested tool

--- a/bioblend/galaxy/toolshed/__init__.py
+++ b/bioblend/galaxy/toolshed/__init__.py
@@ -113,7 +113,6 @@ class ToolShedClient(Client):
         :type install_resolver_dependencies: bool
         :param install_resolver_dependencies: Whether or not to automatically
                                                 install resolver dependencies (e.g. conda).
-                                                This parameter is silently ignored in Galaxy ``release_16.04`` and earlier.
 
         :type tool_panel_section_id: str
         :param tool_panel_section_id: The ID of the Galaxy tool panel section

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -31,15 +31,13 @@ class UserClient(Client):
         :param f_name: filter for user names. The filter will be active for
             non-admin users only if the Galaxy instance has the
             ``expose_user_name`` option set to ``true`` in the
-            ``config/galaxy.yml`` configuration file. This parameter is silently
-            ignored in Galaxy ``release_15.10`` and earlier.
+            ``config/galaxy.yml`` configuration file.
 
         :type f_any: str
         :param f_any: filter for user email or name. Each filter will be active
             for non-admin users only if the Galaxy instance has the
             corresponding ``expose_user_*`` option set to ``true`` in the
-            ``config/galaxy.yml`` configuration file. This parameter is silently
-            ignored in Galaxy ``release_15.10`` and earlier.
+            ``config/galaxy.yml`` configuration file.
 
         :rtype: list
         :return: a list of dicts with user details.
@@ -176,7 +174,6 @@ class UserClient(Client):
     def get_user_apikey(self, user_id):
         """
         Get the current API key for a given user.
-        This functionality is available since Galaxy ``release_17.01``.
 
         :type user_id: str
         :param user_id: encoded user ID

--- a/run_galaxy.sh
+++ b/run_galaxy.sh
@@ -14,63 +14,7 @@ then
     . $GALAXY_LOCAL_ENV_FILE
 fi
 
-if [ -f scripts/common_startup.sh ]; then
-    ./scripts/common_startup.sh || exit 1
-else
-    if [ -f scripts/copy_sample_files.sh ]; then
-        ./scripts/copy_sample_files.sh
-    else
-        SAMPLES="
-            community_wsgi.ini.sample
-            datatypes_conf.xml.sample
-            external_service_types_conf.xml.sample
-            migrated_tools_conf.xml.sample
-            reports_wsgi.ini.sample
-            shed_tool_conf.xml.sample
-            tool_conf.xml.sample
-            shed_tool_data_table_conf.xml.sample
-            tool_data_table_conf.xml.sample
-            tool_sheds_conf.xml.sample
-            data_manager_conf.xml.sample
-            shed_data_manager_conf.xml.sample
-            openid_conf.xml.sample
-            universe_wsgi.ini.sample
-            tool-data/shared/ncbi/builds.txt.sample
-            tool-data/shared/ensembl/builds.txt.sample
-            tool-data/shared/ucsc/builds.txt.sample
-            tool-data/shared/ucsc/publicbuilds.txt.sample
-            tool-data/shared/ucsc/ucsc_build_sites.txt.sample
-            tool-data/shared/igv/igv_build_sites.txt.sample
-            tool-data/shared/rviewer/rviewer_build_sites.txt.sample
-            tool-data/*.sample
-            static/welcome.html.sample
-        "
-        # Create any missing config/location files
-        for sample in $SAMPLES; do
-            file=${sample%.sample}
-            if [ ! -f "$file" -a -f "$sample" ]; then
-                echo "Initializing $file from $(basename "$sample")"
-                cp "$sample" "$file"
-            fi
-        done
-    fi
-    # explicitly attempt to fetch eggs before running
-    FETCH_EGGS=1
-    for arg in "$@"; do
-        [ "$arg" = "--stop-daemon" ] && FETCH_EGGS=0; break
-    done
-    if [ $FETCH_EGGS -eq 1 ]; then
-        if ! python ./scripts/check_eggs.py -q; then
-            echo "Some eggs are out of date, attempting to fetch..."
-            if python ./scripts/fetch_eggs.py; then
-                echo "Fetch successful."
-            else
-                echo "Fetch failed."
-                exit 1
-            fi
-        fi
-    fi
-fi
+./scripts/common_startup.sh || exit 1
 
 # If there is a .venv/ directory, assume it contains a virtualenv that we
 # should run this instance in.
@@ -81,10 +25,6 @@ then
 fi
 
 python ./scripts/check_python.py || exit 1
-
-if [ -n "$GALAXY_UNIVERSE_CONFIG_DIR" ]; then
-    python ./scripts/build_universe_config.py "$GALAXY_UNIVERSE_CONFIG_DIR"
-fi
 
 if [ -z "$GALAXY_CONFIG_FILE" ]; then
     if [ -f universe_wsgi.ini ]; then


### PR DESCRIPTION
- Install virtualenv >=20.0.14 to fix conda commands on macOS
- Use Ubuntu bionic for TravisCI
- Deploy under Python 3.7
- Update psycopg2 requirement to a version compatible with glibc 2.26 for Galaxy releases 16.01-18.01
- Drop support for old Galaxy releases 15.03 - 17.05 which don't start without multiple patches due to broken Python eggs/wheels download: see e.g. https://travis-ci.org/github/galaxyproject/bioblend/builds/665803989 for eggs, while for wheels the psycopg2 fix above doesn't work without passing the `--extra-index-url` option to `pip`