### PR TITLE
Add documentation for datatype updates

### DIFF
--- a/bioblend/_tests/TestGalaxyHistories.py
+++ b/bioblend/_tests/TestGalaxyHistories.py
@@ -199,14 +199,12 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
     def test_update_dataset_datatype(self):
         history_id = self.history["id"]
         dataset1_id = self._test_dataset(history_id)
-        original_hda = self.gi.datasets.show_dataset(dataset1_id)
         self._wait_and_verify_dataset(dataset1_id, b'1\t2\t3\n')
-        assert original_hda['extension'] == 'auto'
-        assert original_hda['data_type'] == 'galaxy.datatypes.data.Data'
+        original_hda = self.gi.datasets.show_dataset(dataset1_id)
+        assert original_hda['extension'] == 'bed'
         self.gi.histories.update_dataset(history_id, dataset1_id, datatype='tabular')
         updated_hda = self.gi.datasets.show_dataset(dataset1_id)
         assert updated_hda['extension'] == 'tabular'
-        assert updated_hda['data_type'] == 'galaxy.datatypes.tabular.Tabular'
 
     def tearDown(self):
         self.gi.histories.delete_history(self.history['id'], purge=True)

--- a/bioblend/_tests/TestGalaxyHistories.py
+++ b/bioblend/_tests/TestGalaxyHistories.py
@@ -195,5 +195,18 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
         self._wait_and_verify_dataset(copied_dataset['id'], expected_contents)
         self.gi.histories.delete_history(self.history_id2, purge=True)
 
+    @test_util.skip_unless_galaxy('release_20.09')
+    def test_update_dataset_datatype(self):
+        history_id = self.history["id"]
+        dataset1_id = self._test_dataset(history_id)
+        original_hda = self.gi.datasets.show_dataset(dataset1_id)
+        self._wait_and_verify_dataset(dataset1_id, b'1\t2\t3\n')
+        assert original_hda['extension'] == 'auto'
+        assert original_hda['data_type'] == 'galaxy.datatypes.data.Data'
+        self.gi.histories.update_dataset(history_id, dataset1_id, datatype='tabular')
+        updated_hda = self.gi.datasets.show_dataset(dataset1_id)
+        assert updated_hda['extension'] == 'tabular'
+        assert updated_hda['data_type'] == 'galaxy.datatypes.tabular.Tabular'
+
     def tearDown(self):
         self.gi.histories.delete_history(self.history['id'], purge=True)

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -318,10 +318,17 @@ class HistoryClient(Client):
         :param history_id: Encoded history ID
 
         :type dataset_id: str
-        :param dataset_id: Id of the dataset
+        :param dataset_id: ID of the dataset
 
         :type name: str
         :param name: Replace history dataset name with the given string
+
+        :type datatype: str
+        :param datatype: Replace the datatype of the history dataset with the
+          given string. The string must be a valid Galaxy datatype, both the
+          current and the target datatypes must allow datatype changes, and the
+          dataset must not be in use as input or output of a running job
+          (including uploads), otherwise an error will be raised.
 
         :type genome_build: str
         :param genome_build: Replace history dataset genome build (dbkey)


### PR DESCRIPTION
To make it clear in the documentation that datatypes can be modified through bioblend.

Fixes #243.