### PR TITLE
replace param 'key' with header 'x-api-key'

### DIFF
--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -71,7 +71,7 @@ class GalaxyClient:
         headers['x-api-key'] = self.key
         kwargs.setdefault('verify', self.verify)
         kwargs.setdefault('timeout', self.timeout)
-        r = requests.get(url, **kwargs)
+        r = requests.get(url, headers=headers, **kwargs)
         return r
 
     def make_post_request(self, url, payload, params=None, files_attached=False):

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -44,7 +44,7 @@ class GalaxyClient:
             self.password = password
         self.json_headers = {
             'Content-Type': 'application/json',
-            'x-api-key': key
+            'x-api-key': self.key,
         }
         self.verify = verify
         self.timeout = timeout
@@ -65,12 +65,7 @@ class GalaxyClient:
         :rtype: requests.Response
         :return: the response object.
         """
-        params = kwargs.get('params')
-        if params is not None:
-            # remove 'key' if present, use header 'x-api-key' instead
-            params.pop('key', None)
-        kwargs['params'] = params
-        headers = self.json_headers.copy()
+        headers = self.json_headers
         kwargs.setdefault('verify', self.verify)
         kwargs.setdefault('timeout', self.timeout)
         r = requests.get(url, headers=headers, **kwargs)
@@ -101,21 +96,17 @@ class GalaxyClient:
                     d[k] = json.dumps(v)
             return d
 
-        if params is not None and params.get('key', False) is False:
-            params['key'] = self.key
-        else:
-            params = self.default_params
-
         # Compute data, headers, params arguments for request.post,
         # leveraging the requests-toolbelt library if any files have
         # been attached.
         if files_attached:
             payload = my_dumps(payload)
-            payload.update(params)
+            if params:
+                payload.update(params)
             payload = MultipartEncoder(fields=payload)
             headers = self.json_headers.copy()
             headers['Content-Type'] = payload.content_type
-            post_params = {}
+            post_params = None
         else:
             payload = json.dumps(payload)
             headers = self.json_headers
@@ -150,10 +141,6 @@ class GalaxyClient:
         :rtype: requests.Response
         :return: the response object.
         """
-        if params is not None and params.get('key', False) is False:
-            params['key'] = self.key
-        else:
-            params = self.default_params
         if payload is not None:
             payload = json.dumps(payload)
         headers = self.json_headers
@@ -170,11 +157,6 @@ class GalaxyClient:
 
         :return: The decoded response.
         """
-        if params is not None and params.get('key', False) is False:
-            params['key'] = self.key
-        else:
-            params = self.default_params
-
         payload = json.dumps(payload)
         headers = self.json_headers
         r = requests.put(url, data=payload, params=params, headers=headers,
@@ -198,11 +180,6 @@ class GalaxyClient:
 
         :return: The decoded response.
         """
-        if params is not None and params.get('key', False) is False:
-            params['key'] = self.key
-        else:
-            params = self.default_params
-
         payload = json.dumps(payload)
         headers = self.json_headers
         r = requests.patch(url, data=payload, params=params, headers=headers,
@@ -236,7 +213,3 @@ class GalaxyClient:
                 response = json.loads(response)
             self._key = response["api_key"]
         return self._key
-
-    @property
-    def default_params(self):
-        return {'key': self.key}

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -63,11 +63,12 @@ class GalaxyClient:
         :return: the response object.
         """
         params = kwargs.get('params')
-        if params is not None and params.get('key', False) is False:
-            params['key'] = self.key
-        else:
-            params = self.default_params
+        if params is not None:
+            # remove 'key' if present, use header 'x-api-key' instead
+            params.pop('key', None)
         kwargs['params'] = params
+        headers = self.json_headers.copy()
+        headers['x-api-key'] = self.key
         kwargs.setdefault('verify', self.verify)
         kwargs.setdefault('timeout', self.timeout)
         r = requests.get(url, **kwargs)

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -42,7 +42,10 @@ class GalaxyClient:
             self._key = None
             self.email = email
             self.password = password
-        self.json_headers = {'Content-Type': 'application/json'}
+        self.json_headers = {
+            'Content-Type': 'application/json',
+            'x-api-key': key
+        }
         self.verify = verify
         self.timeout = timeout
 
@@ -68,7 +71,6 @@ class GalaxyClient:
             params.pop('key', None)
         kwargs['params'] = params
         headers = self.json_headers.copy()
-        headers['x-api-key'] = self.key
         kwargs.setdefault('verify', self.verify)
         kwargs.setdefault('timeout', self.timeout)
         r = requests.get(url, headers=headers, **kwargs)


### PR DESCRIPTION
in GalaxyClient.make_get_request()

As mentioned by @nsoranzo in galaxyproject/galaxy#11375. This also fixes the 'key' error when making an API request.
Not sure if I did it right, but it's a starting point.