### PR TITLE
JobsClient.get_jobs method filtering

### DIFF
--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -69,7 +69,6 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         jobs = user2_gi.jobs.get_jobs(history_id=history_id2)
         self.assertEqual(len(jobs), 1)
         jobs = self.gi.jobs.get_jobs(user_details=True)
-        self.assertEqual(len(jobs), 4)
         self.assertEqual(len([x for x in jobs if x['history_id'] == history_id1]), 3)
         self.assertEqual(len([x for x in jobs if x['history_id'] == history_id2]), 1)
 

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -1,3 +1,7 @@
+import os
+from datetime import datetime, timedelta
+from bioblend import galaxy
+
 from . import (
     GalaxyTestBase,
     test_util
@@ -5,6 +9,70 @@ from . import (
 
 
 class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
+    @test_util.skip_unless_tool("random_lines1")
+    def test_get_jobs(self):
+        user1 = self.gi.users.create_local_user('user1', 'email1@email.test', 'password1')
+        user2 = self.gi.users.create_local_user('user2', 'email2@email.test', 'password2')
+        key1 = self.gi.users.create_user_apikey(user1['id'])
+        key2 = self.gi.users.create_user_apikey(user2['id'])
+        user1_gi = galaxy.GalaxyInstance(url=self.gi.base_url, key=key1)
+        user2_gi = galaxy.GalaxyInstance(url=self.gi.base_url, key=key2)
+
+        history_id1 = user1_gi.histories.create_history(name="test_run_random_lines history1")["id"]
+        dataset_id1 = user1_gi.tools.paste_content("line 1\nline 2\rline 3\r\nline 4", history_id1)["outputs"][0]["id"]
+        tool_inputs = {
+            'num_lines': '1',
+            'input': {
+                'src': 'hda',
+                'id': dataset_id1
+            },
+            'seed_source': {
+                'seed_source_selector': 'set_seed',
+                'seed': 'asdf'
+            }
+        }
+        user1_gi.tools.run_tool(
+            history_id=history_id1,
+            tool_id="random_lines1",
+            tool_inputs=tool_inputs,
+            input_format='21.01'
+        )
+        user1_gi.tools.run_tool(
+            history_id=history_id1,
+            tool_id="random_lines1",
+            tool_inputs=tool_inputs,
+            input_format='21.01'
+        )
+
+        path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
+        wf = user2_gi.workflows.import_workflow_from_local_path(path)
+        history_id2 = user2_gi.histories.create_history(name="test_wf_invocation")['id']
+        dataset_id2 = user2_gi.tools.paste_content("line 1\nline 2\rline 3\r\nline 4", history_id2)["outputs"][0]["id"]
+        dataset = {'src': 'hda', 'id': dataset_id2}
+        user2_gi.workflows.invoke_workflow(
+            wf['id'],
+            inputs={'Input 1': dataset, 'Input 2': dataset},
+            history_id=history_id2,
+            inputs_by='name',
+        )
+
+        jobs = user1_gi.jobs.get_jobs(tool_id='random_lines1')
+        self.assertEqual(len(jobs), 2)
+        yesterday = datetime.today() - timedelta(days=1)
+        jobs = user1_gi.jobs.get_jobs(date_range_max=yesterday.strftime('%Y-%m-%d'))
+        self.assertEqual(len(jobs), 0)
+        tomorrow = datetime.today() + timedelta(days=1)
+        jobs = user1_gi.jobs.get_jobs(date_range_min=tomorrow.strftime('%Y-%m-%d'))
+        self.assertEqual(len(jobs), 0)
+        jobs = user1_gi.jobs.get_jobs(date_range_min=datetime.today().strftime('%Y-%m-%d'))
+        self.assertEqual(len(jobs), 3)
+        jobs = user2_gi.jobs.get_jobs(history_id=history_id2)
+        self.assertEqual(len(jobs), 1)
+        jobs = self.gi.jobs.get_jobs(user_details=True)
+        self.assertEqual(len(jobs), 4)
+        self.assertEqual(len([x for x in jobs if x['history_id'] == history_id1]), 3)
+        self.assertEqual(len([x for x in jobs if x['history_id'] == history_id2]), 1)
+
     @test_util.skip_unless_galaxy('release_21.01')
     @test_util.skip_unless_tool("random_lines1")
     def test_run_and_rerun_random_lines(self):

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -70,7 +70,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         jobs = self.gi.jobs.get_jobs(tool_id='random_lines1', history_id=history_id, state='failed')
         self.assertEqual(len(jobs), 0)
         yesterday = datetime.today() - timedelta(days=1)
-        jobs = self.gi.jobs.get_jobs(date_range_max=yesterday.strftime('%Y-%m-%d'))
+        jobs = self.gi.jobs.get_jobs(date_range_max=yesterday.strftime('%Y-%m-%d'), history_id=history_id)
         self.assertEqual(len(jobs), 0)
         tomorrow = datetime.today() + timedelta(days=1)
         jobs = self.gi.jobs.get_jobs(date_range_min=tomorrow.strftime('%Y-%m-%d'))

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -1,7 +1,5 @@
-import os
 from datetime import datetime, timedelta
 
-from bioblend import galaxy
 from . import (
     GalaxyTestBase,
     test_util
@@ -11,66 +9,44 @@ from . import (
 class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     @test_util.skip_unless_tool("random_lines1")
     def test_get_jobs(self):
-        user1 = self.gi.users.create_local_user('user1', 'email1@email.test', 'password1')
-        user2 = self.gi.users.create_local_user('user2', 'email2@email.test', 'password2')
-        key1 = self.gi.users.create_user_apikey(user1['id'])
-        key2 = self.gi.users.create_user_apikey(user2['id'])
-        user1_gi = galaxy.GalaxyInstance(url=self.gi.base_url, key=key1)
-        user2_gi = galaxy.GalaxyInstance(url=self.gi.base_url, key=key2)
-
-        history_id1 = user1_gi.histories.create_history(name="test_run_random_lines history1")["id"]
-        dataset_id1 = user1_gi.tools.paste_content("line 1\nline 2\rline 3\r\nline 4", history_id1)["outputs"][0]["id"]
+        history_id = self.gi.histories.create_history(name="test_get_jobs history1")["id"]
+        dataset_id = self.gi.tools.paste_content("line 1\nline 2\rline 3\r\nline 4", history_id)["outputs"][0]["id"]
         tool_inputs = {
             'num_lines': '1',
             'input': {
                 'src': 'hda',
-                'id': dataset_id1
+                'id': dataset_id
             },
             'seed_source': {
                 'seed_source_selector': 'set_seed',
                 'seed': 'asdf'
             }
         }
-        user1_gi.tools.run_tool(
-            history_id=history_id1,
+        self.gi.tools.run_tool(
+            history_id=history_id,
             tool_id="random_lines1",
             tool_inputs=tool_inputs,
             input_format='21.01'
         )
-        user1_gi.tools.run_tool(
-            history_id=history_id1,
+        self.gi.tools.run_tool(
+            history_id=history_id,
             tool_id="random_lines1",
             tool_inputs=tool_inputs,
             input_format='21.01'
         )
 
-        path = test_util.get_abspath(os.path.join('data', 'paste_columns.ga'))
-        wf = user2_gi.workflows.import_workflow_from_local_path(path)
-        history_id2 = user2_gi.histories.create_history(name="test_wf_invocation")['id']
-        dataset_id2 = user2_gi.tools.paste_content("line 1\nline 2\rline 3\r\nline 4", history_id2)["outputs"][0]["id"]
-        dataset = {'src': 'hda', 'id': dataset_id2}
-        user2_gi.workflows.invoke_workflow(
-            wf['id'],
-            inputs={'Input 1': dataset, 'Input 2': dataset},
-            history_id=history_id2,
-            inputs_by='name',
-        )
-
-        jobs = user1_gi.jobs.get_jobs(tool_id='random_lines1')
+        jobs = self.gi.jobs.get_jobs(tool_id='random_lines1', history_id=history_id, state='new')
         self.assertEqual(len(jobs), 2)
+        jobs = self.gi.jobs.get_jobs(tool_id='random_lines1', history_id=history_id, state='failed')
+        self.assertEqual(len(jobs), 0)
         yesterday = datetime.today() - timedelta(days=1)
-        jobs = user1_gi.jobs.get_jobs(date_range_max=yesterday.strftime('%Y-%m-%d'))
+        jobs = self.gi.jobs.get_jobs(date_range_max=yesterday.strftime('%Y-%m-%d'))
         self.assertEqual(len(jobs), 0)
         tomorrow = datetime.today() + timedelta(days=1)
-        jobs = user1_gi.jobs.get_jobs(date_range_min=tomorrow.strftime('%Y-%m-%d'))
+        jobs = self.gi.jobs.get_jobs(date_range_min=tomorrow.strftime('%Y-%m-%d'))
         self.assertEqual(len(jobs), 0)
-        jobs = user1_gi.jobs.get_jobs(date_range_min=datetime.today().strftime('%Y-%m-%d'))
+        jobs = self.gi.jobs.get_jobs(date_range_min=datetime.today().strftime('%Y-%m-%d'), history_id=history_id)
         self.assertEqual(len(jobs), 3)
-        jobs = user2_gi.jobs.get_jobs(history_id=history_id2)
-        self.assertEqual(len(jobs), 1)
-        jobs = self.gi.jobs.get_jobs(user_details=True)
-        self.assertEqual(len([x for x in jobs if x['history_id'] == history_id1]), 3)
-        self.assertEqual(len([x for x in jobs if x['history_id'] == history_id2]), 1)
 
     @test_util.skip_unless_galaxy('release_21.01')
     @test_util.skip_unless_tool("random_lines1")

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime, timedelta
-from bioblend import galaxy
 
+from bioblend import galaxy
 from . import (
     GalaxyTestBase,
     test_util

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -39,13 +39,11 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
 
     @test_util.skip_unless_tool("random_lines1")
     def test_get_jobs(self):
-        history_id = self.gi.histories.create_history(name="test_get_jobs history1")["id"]
-        dataset_id = self.gi.tools.paste_content("line 1\nline 2\rline 3\r\nline 4", history_id)["outputs"][0]["id"]
         tool_inputs = {
             'num_lines': '1',
             'input': {
                 'src': 'hda',
-                'id': dataset_id
+                'id': self.dataset_id
             },
             'seed_source': {
                 'seed_source_selector': 'set_seed',
@@ -53,29 +51,29 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
             }
         }
         self.gi.tools.run_tool(
-            history_id=history_id,
+            history_id=self.history_id,
             tool_id="random_lines1",
             tool_inputs=tool_inputs,
             input_format='21.01'
         )
         self.gi.tools.run_tool(
-            history_id=history_id,
+            history_id=self.history_id,
             tool_id="random_lines1",
             tool_inputs=tool_inputs,
             input_format='21.01'
         )
 
-        jobs = self.gi.jobs.get_jobs(tool_id='random_lines1', history_id=history_id, state='new')
+        jobs = self.gi.jobs.get_jobs(tool_id='random_lines1', history_id=self.history_id)
         self.assertEqual(len(jobs), 2)
-        jobs = self.gi.jobs.get_jobs(tool_id='random_lines1', history_id=history_id, state='failed')
+        jobs = self.gi.jobs.get_jobs(history_id=self.history_id, state='failed')
         self.assertEqual(len(jobs), 0)
         yesterday = datetime.today() - timedelta(days=1)
-        jobs = self.gi.jobs.get_jobs(date_range_max=yesterday.strftime('%Y-%m-%d'), history_id=history_id)
+        jobs = self.gi.jobs.get_jobs(date_range_max=yesterday.strftime('%Y-%m-%d'), history_id=self.history_id)
         self.assertEqual(len(jobs), 0)
         tomorrow = datetime.today() + timedelta(days=1)
         jobs = self.gi.jobs.get_jobs(date_range_min=tomorrow.strftime('%Y-%m-%d'))
         self.assertEqual(len(jobs), 0)
-        jobs = self.gi.jobs.get_jobs(date_range_min=datetime.today().strftime('%Y-%m-%d'), history_id=history_id)
+        jobs = self.gi.jobs.get_jobs(date_range_min=datetime.today().strftime('%Y-%m-%d'), history_id=self.history_id)
         self.assertEqual(len(jobs), 3)
 
     @test_util.skip_unless_galaxy('release_21.01')

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -21,7 +21,7 @@ class JobsClient(Client):
         super().__init__(galaxy_instance)
 
     def get_jobs(self, state=None, tool_id=None, user_details=None,
-                 date_range_min=None, date_range_max=None,
+                 limit=500, offset=0, date_range_min=None, date_range_max=None,
                  history_id=None, workflow_id=None, invocation_id=None):
         """
         Get the list of jobs of the current user.
@@ -40,6 +40,14 @@ class JobsClient(Client):
         :type user_details: boolean
         :param user_details: If true, and requestor is an admin, will return
                              external job id and user email.
+
+        :type limit: int
+        :param limit: Maximum number of jobs to return.
+
+        :type offset: int
+        :param offset: Return jobs starting from this specified position.
+                       For example, if ``limit`` is set to 100 and ``offset`` to 200,
+                       jobs 200-299 will be returned.
 
         :type date_range_min: string '2014-01-01'
         :param date_range_min: Limit the listing of jobs to those updated on
@@ -80,7 +88,10 @@ class JobsClient(Client):
               'tool_id': 'upload1',
               'update_time': '2014-03-01T16:05:39.558458'}]
         """
-        params = {}
+        params = {
+            limit: limit,
+            offset: offset
+        }
         if state:
             params['state'] = state
         if tool_id:

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -20,9 +20,46 @@ class JobsClient(Client):
         self.module = 'jobs'
         super().__init__(galaxy_instance)
 
-    def get_jobs(self):
+    def get_jobs(self, state=None, tool_id=None, user_details=None,
+                 date_range_min=None, date_range_max=None,
+                 history_id=None, workflow_id=None, invocation_id=None):
         """
         Get the list of jobs of the current user.
+
+        If the user is an admin and user_details is True, then this will
+        get jobs for all galaxy users based on filtering.
+
+        :type state: string or list
+        :param state: Limit listing of jobs to those that match one of the
+                      included states. If none, all are returned.
+
+        :type tool_id: string or list
+        :param tool_id: Limit listing of jobs to those that match one of the
+                        included tool_ids. If none, all are returned.
+
+        :type user_details: boolean
+        :param user_details: If true, and requestor is an admin, will return
+                             external job id and user email.
+
+        :type date_range_min: string '2014-01-01'
+        :param date_range_min: Limit the listing of jobs to those updated on
+                               or after this date.
+
+        :type date_range_max: string '2014-12-31'
+        :param date_range_max: Limit the listing of jobs to those updated on
+                               or before this date.
+
+        :type history_id: string
+        :param history_id: Limit listing of jobs to those that match the
+                           history_id. If none, all are returned.
+
+        :type workflow_id: string
+        :param workflow_id: Limit listing of jobs to those that match the
+                           workflow_id. If none, all are returned.
+
+        :type invocation_id: string
+        :param invocation_id: Limit listing of jobs to those that match the
+                           invocation_id. If none, all are returned.
 
         :rtype: list
         :return: list of dictionaries containing summary job information.
@@ -43,7 +80,24 @@ class JobsClient(Client):
               'tool_id': 'upload1',
               'update_time': '2014-03-01T16:05:39.558458'}]
         """
-        return self._get()
+        params = {}
+        if state:
+            params['state'] = state
+        if tool_id:
+            params['tool_id'] = tool_id
+        if user_details:
+            params['user_details'] = user_details
+        if date_range_min:
+            params['date_range_min'] = date_range_min
+        if date_range_max:
+            params['date_range_max'] = date_range_max
+        if history_id:
+            params['history_id'] = history_id
+        if workflow_id:
+            params['workflow_id'] = workflow_id
+        if invocation_id:
+            params['invocation_id'] = invocation_id
+        return self._get(params=params)
 
     def show_job(self, job_id, full_details=False):
         """

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -20,7 +20,7 @@ class JobsClient(Client):
         self.module = 'jobs'
         super().__init__(galaxy_instance)
 
-    def get_jobs(self, state=None, tool_id=None, user_details=None,
+    def get_jobs(self, state=None, tool_id=None, user_details=False,
                  date_range_min=None, date_range_max=None, history_id=None):
         """
         Get the list of jobs of the current user.

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -21,8 +21,7 @@ class JobsClient(Client):
         super().__init__(galaxy_instance)
 
     def get_jobs(self, state=None, tool_id=None, user_details=None,
-                 limit=500, offset=0, date_range_min=None, date_range_max=None,
-                 history_id=None, workflow_id=None, invocation_id=None):
+                 date_range_min=None, date_range_max=None, history_id=None):
         """
         Get the list of jobs of the current user.
 
@@ -41,14 +40,6 @@ class JobsClient(Client):
         :param user_details: If true, and requestor is an admin, will return
                              external job id and user email.
 
-        :type limit: int
-        :param limit: Maximum number of jobs to return.
-
-        :type offset: int
-        :param offset: Return jobs starting from this specified position.
-                       For example, if ``limit`` is set to 100 and ``offset`` to 200,
-                       jobs 200-299 will be returned.
-
         :type date_range_min: string '2014-01-01'
         :param date_range_min: Limit the listing of jobs to those updated on
                                or after this date.
@@ -60,14 +51,6 @@ class JobsClient(Client):
         :type history_id: string
         :param history_id: Limit listing of jobs to those that match the
                            history_id. If none, all are returned.
-
-        :type workflow_id: string
-        :param workflow_id: Limit listing of jobs to those that match the
-                           workflow_id. If none, all are returned.
-
-        :type invocation_id: string
-        :param invocation_id: Limit listing of jobs to those that match the
-                           invocation_id. If none, all are returned.
 
         :rtype: list
         :return: list of dictionaries containing summary job information.
@@ -88,10 +71,7 @@ class JobsClient(Client):
               'tool_id': 'upload1',
               'update_time': '2014-03-01T16:05:39.558458'}]
         """
-        params = {
-            limit: limit,
-            offset: offset
-        }
+        params = {}
         if state:
             params['state'] = state
         if tool_id:
@@ -104,10 +84,6 @@ class JobsClient(Client):
             params['date_range_max'] = date_range_max
         if history_id:
             params['history_id'] = history_id
-        if workflow_id:
-            params['workflow_id'] = workflow_id
-        if invocation_id:
-            params['invocation_id'] = invocation_id
         return self._get(params=params)
 
     def show_job(self, job_id, full_details=False):

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -23,37 +23,35 @@ class JobsClient(Client):
     def get_jobs(self, state=None, tool_id=None, user_details=False,
                  date_range_min=None, date_range_max=None, history_id=None):
         """
-        Get the list of jobs of the current user.
+        Get all jobs, or select a subset by specifying optional arguments for
+        filtering (e.g. a state).
 
-        If the user is an admin and user_details is True, then this will
-        get jobs for all galaxy users based on filtering.
+        If the user is an admin, this will return jobs for all the users,
+        otherwise only for the current user.
 
-        :type state: string or list
-        :param state: Limit listing of jobs to those that match one of the
-                      included states. If none, all are returned.
+        :type state: str or list of str
+        :param state: Job states to filter on.
 
-        :type tool_id: string or list
-        :param tool_id: Limit listing of jobs to those that match one of the
-                        included tool_ids. If none, all are returned.
+        :type tool_id: str or list of str
+        :param tool_id: Tool IDs to filter on.
 
-        :type user_details: boolean
-        :param user_details: If true, and requestor is an admin, will return
-                             external job id and user email.
+        :type user_details: bool
+        :param user_details: If ``True`` and the user is an admin, add the user
+          email to each returned job dictionary.
 
-        :type date_range_min: string '2014-01-01'
-        :param date_range_min: Limit the listing of jobs to those updated on
-                               or after this date.
+        :type date_range_min: str
+        :param date_range_min: Mininum job update date (in YYYY-MM-DD format) to
+          filter on.
 
-        :type date_range_max: string '2014-12-31'
-        :param date_range_max: Limit the listing of jobs to those updated on
-                               or before this date.
+        :type date_range_max: str
+        :param date_range_max: Maximum job update date (in YYYY-MM-DD format) to
+          filter on.
 
-        :type history_id: string
-        :param history_id: Limit listing of jobs to those that match the
-                           history_id. If none, all are returned.
+        :type history_id: str
+        :param history_id: Encoded history ID to filter on.
 
-        :rtype: list
-        :return: list of dictionaries containing summary job information.
+        :rtype: list of dict
+        :return: Summary information for each selected job.
           For example::
 
             [{'create_time': '2014-03-01T16:16:48.640550',


### PR DESCRIPTION
The parameters `workflow_id`, `invocation_id`, `limit`, `offset` are not yet implemented in Galaxy, Maybe `user_id` filtering for admins would be nice as well, just like in get_invocations.

Related issue: #373