### PR TITLE
Add function to get /dependency_resolvers/toolbox

### DIFF
--- a/bioblend/_tests/TestGalaxyToolDependencies.py
+++ b/bioblend/_tests/TestGalaxyToolDependencies.py
@@ -2,7 +2,7 @@
 """
 Test functions in bioblend.galaxy.tool_dependencies
 """
-from . import GalaxyTestBase
+from . import GalaxyTestBase, test_util
 
 
 class TestGalaxyToolDependencies(GalaxyTestBase.GalaxyTestBase):

--- a/bioblend/_tests/TestGalaxyToolDependencies.py
+++ b/bioblend/_tests/TestGalaxyToolDependencies.py
@@ -13,7 +13,7 @@ class TestGalaxyToolDependencies(GalaxyTestBase.GalaxyTestBase):
         self.assertTrue(isinstance(toolbox_summary, list))
         self.assertGreater(len(toolbox_summary), 0)
 
-        toolbox_summary_by_tool = self.gi.tool_dependencies.summarize_toolbox(index_by='tool')
+        toolbox_summary_by_tool = self.gi.tool_dependencies.summarize_toolbox(index_by='tools')
         self.assertTrue(isinstance(toolbox_summary_by_tool, list))
         self.assertGreater(len(toolbox_summary_by_tool), 0)
         self.assertTrue(isinstance(toolbox_summary_by_tool[0], dict))
@@ -21,7 +21,7 @@ class TestGalaxyToolDependencies(GalaxyTestBase.GalaxyTestBase):
         self.assertTrue(isinstance(toolbox_summary_by_tool[0]['tool_ids'], list))
         tool_id = toolbox_summary_by_tool[0]['tool_ids'][0]
 
-        toolbox_summary_select_tool_ids = self.gi.tool_dependencies.summarize_toolbox(index_by='tool', tool_ids=[tool_id])
+        toolbox_summary_select_tool_ids = self.gi.tool_dependencies.summarize_toolbox(index_by='tools', tool_ids=[tool_id])
         self.assertTrue(isinstance(toolbox_summary_select_tool_ids, list))
         self.assertEqual(len(toolbox_summary_select_tool_ids), 1)
         self.assertEqual(toolbox_summary_select_tool_ids[0]['tool_ids'][0], tool_id)

--- a/bioblend/_tests/TestGalaxyToolDependencies.py
+++ b/bioblend/_tests/TestGalaxyToolDependencies.py
@@ -7,6 +7,7 @@ from . import GalaxyTestBase
 
 class TestGalaxyToolDependencies(GalaxyTestBase.GalaxyTestBase):
 
+    @test_util.skip_unless_galaxy('release_20.01')
     def test_summarize_toolbox(self):
         toolbox_summary = self.gi.tool_dependencies.summarize_toolbox()
         self.assertTrue(isinstance(toolbox_summary, list))

--- a/bioblend/_tests/TestGalaxyToolDependencies.py
+++ b/bioblend/_tests/TestGalaxyToolDependencies.py
@@ -1,0 +1,26 @@
+
+"""
+Test functions in bioblend.galaxy.tool_dependencies
+"""
+from . import GalaxyTestBase
+
+
+class TestGalaxyToolDependencies(GalaxyTestBase.GalaxyTestBase):
+
+    def test_summarize_toolbox(self):
+        toolbox_summary = self.gi.tool_dependencies.summarize_toolbox()
+        self.assertTrue(isinstance(toolbox_summary, list))
+        self.assertGreater(len(toolbox_summary), 0)
+
+        toolbox_summary_by_tool = self.gi.tool_dependencies.summarize_toolbox(index_by='tool')
+        self.assertTrue(isinstance(toolbox_summary_by_tool, list))
+        self.assertGreater(len(toolbox_summary_by_tool), 0)
+        self.assertTrue(isinstance(toolbox_summary_by_tool[0], dict))
+        self.assertTrue('tool_ids' in toolbox_summary_by_tool[0])
+        self.assertTrue(isinstance(toolbox_summary_by_tool[0]['tool_ids'], list))
+        tool_id = toolbox_summary_by_tool[0]['tool_ids'][0]
+
+        toolbox_summary_select_tool_ids = self.gi.tool_dependencies.summarize_toolbox(index_by='tool', tool_ids=[tool_id])
+        self.assertTrue(isinstance(toolbox_summary_select_tool_ids, list))
+        self.assertEqual(len(toolbox_summary_select_tool_ids), 1)
+        self.assertEqual(toolbox_summary_select_tool_ids[0]['tool_ids'][0], tool_id)

--- a/bioblend/galaxy/__init__.py
+++ b/bioblend/galaxy/__init__.py
@@ -4,8 +4,8 @@ A base representation of an instance of Galaxy
 from bioblend.galaxy import (config, datasets, datatypes, folders, forms,
                              ftpfiles, genomes, groups, histories,
                              invocations, jobs, libraries, quotas, roles,
-                             tool_data, tools, toolshed, users, visual,
-                             workflows)
+                             tool_data, tool_dependencies, tools, toolshed,
+                             users, visual, workflows)
 from bioblend.galaxy.client import Client
 from bioblend.galaxyclient import GalaxyClient
 
@@ -75,6 +75,7 @@ class GalaxyInstance(GalaxyClient):
         self.ftpfiles = ftpfiles.FTPFilesClient(self)
         self.tool_data = tool_data.ToolDataClient(self)
         self.folders = folders.FoldersClient(self)
+        self.tool_dependencies = tool_dependencies.ToolDependenciesClient(self)
 
     @property
     def max_get_attempts(self):

--- a/bioblend/galaxy/tool_dependencies/__init__.py
+++ b/bioblend/galaxy/tool_dependencies/__init__.py
@@ -12,8 +12,6 @@ class ToolDependenciesClient(Client):
 
     def summarize_toolbox(self, index=None, tool_ids=None, resolver_type=None, include_containers=None, container_type=None, index_by=None):
         """
-        GET /api/dependency_resolvers/toolbox
-
         Summarize requirements across toolbox (for Tool Management grid). This is an experimental
         API particularly tied to the GUI - expect breaking changes until this notice is removed.
 

--- a/bioblend/galaxy/tool_dependencies/__init__.py
+++ b/bioblend/galaxy/tool_dependencies/__init__.py
@@ -15,7 +15,8 @@ class ToolDependenciesClient(Client):
         Summarize requirements across toolbox (for Tool Management grid).
 
         :type index: int
-        :param index: index of the dependency resolver
+        :param index: index of the dependency resolver with respect to
+            the dependency resolvers config file
 
         :type tool_ids: list
         :param tool_ids: tool_ids to return when index_by=tools

--- a/bioblend/galaxy/tool_dependencies/__init__.py
+++ b/bioblend/galaxy/tool_dependencies/__init__.py
@@ -1,0 +1,82 @@
+"""
+Contains possible interaction dealing with Galaxy dependency resolvers.
+"""
+from bioblend.galaxy.client import Client
+
+
+class ToolDependenciesClient(Client):
+
+    def __init__(self, galaxy_instance):
+        self.module = 'dependency_resolvers'
+        super().__init__(galaxy_instance)
+
+    def summarize_toolbox(self, index=None, tool_ids=None, resolver_type=None, include_containers=None, container_type=None, index_by=None):
+        """
+        GET /api/dependency_resolvers/toolbox
+
+        Summarize requirements across toolbox (for Tool Management grid). This is an experiemental
+        API particularly tied to the GUI - expect breaking changes until this notice is removed.
+
+        :type index: int
+        :param index: index of the dependency resolver
+
+        :type tool_ids: list
+        :param tool_ids: tool_ids to return when index_by=tool
+
+        :type resolver_type: str
+        :param resolver_type: restrict to specified resolver type
+
+        :type include_containers: bool
+        :param include_containers: include container resolvers in resolution
+
+        :type container_type: str
+        :param container_type: restrict to specified container type
+
+        :type index_by: str
+        :param index_by: By default results are grouped by requirements.  Set to 'tool'
+            to return one entry per tool.
+
+        :rtype: list of dicts
+        :returns: dictified descriptions of the dependencies, with attribute
+            `dependency_type: None` if no match was found.
+            For example::
+
+            [{'requirements': [{'name': 'galaxy_sequence_utils',
+                                'specs': [],
+                                'type': 'package',
+                                'version': '1.1.4'},
+                               {'name': 'bx-python',
+                                'specs': [],
+                                'type': 'package',
+                                'version': '0.8.6'}],
+              'status': [{'cacheable': False,
+                          'dependency_type': None,
+                          'exact': True,
+                          'model_class': 'NullDependency',
+                          'name': 'galaxy_sequence_utils',
+                          'version': '1.1.4'},
+                          {'cacheable': False,
+                          'dependency_type': None,
+                          'exact': True,
+                          'model_class': 'NullDependency',
+                          'name': 'bx-python',
+                          'version': '0.8.6'}],
+              'tool_ids': ['vcf_to_maf_customtrack1']}]
+        """
+
+        params = {}
+        if index:
+            params['index'] = str(index)
+        if tool_ids:
+            params['tool_ids'] = ','.join(tool_ids)
+        if resolver_type:
+            params['resolver_type'] = resolver_type
+        if include_containers is not None:
+            params['include_containers'] = str(include_containers)
+        if container_type:
+            params['container_type'] = container_type
+        if index_by:
+            params['index_by'] = index_by
+
+        url = self._make_url() + '/toolbox'
+        return self._get(url=url, params=params)

--- a/bioblend/galaxy/tool_dependencies/__init__.py
+++ b/bioblend/galaxy/tool_dependencies/__init__.py
@@ -10,19 +10,15 @@ class ToolDependenciesClient(Client):
         self.module = 'dependency_resolvers'
         super().__init__(galaxy_instance)
 
-    def summarize_toolbox(self, index=None, tool_ids=None, resolver_type=None, include_containers=None, container_type=None, index_by=None):
+    def summarize_toolbox(self, index=None, tool_ids=None, resolver_type=None, include_containers=False, container_type=None, index_by='requirements'):
         """
-        Summarize requirements across toolbox (for Tool Management grid). This is an experimental
-        API particularly tied to the GUI - expect breaking changes until this notice is removed.
-
-        This API endpoint is available on Galaxy version 20.01 or later.
-        This functionality is available only to Galaxy admins.
+        Summarize requirements across toolbox (for Tool Management grid).
 
         :type index: int
         :param index: index of the dependency resolver
 
         :type tool_ids: list
-        :param tool_ids: tool_ids to return when index_by=tool
+        :param tool_ids: tool_ids to return when index_by=tools
 
         :type resolver_type: str
         :param resolver_type: restrict to specified resolver type
@@ -34,7 +30,7 @@ class ToolDependenciesClient(Client):
         :param container_type: restrict to specified container type
 
         :type index_by: str
-        :param index_by: By default results are grouped by requirements.  Set to 'tool'
+        :param index_by: By default results are grouped by requirements.  Set to 'tools'
             to return one entry per tool.
 
         :rtype: list of dicts
@@ -63,21 +59,24 @@ class ToolDependenciesClient(Client):
                           'name': 'bx-python',
                           'version': '0.8.6'}],
               'tool_ids': ['vcf_to_maf_customtrack1']}]
+        .. note::
+          This method can only be used with Galaxy ``release_20.01`` or later and requires
+            the user to be an admin. It relies on an experimental API particularly tied to
+            the GUI and therefore is subject to breaking changes.
         """
-
-        params = {}
+        assert index_by in ['tools', 'requirements'], "index_by must be one of 'tools' or 'requirements'."
+        params = {
+            'include_containers': str(include_containers),
+            'index_by': index_by,
+        }
         if index:
             params['index'] = str(index)
         if tool_ids:
             params['tool_ids'] = ','.join(tool_ids)
         if resolver_type:
             params['resolver_type'] = resolver_type
-        if include_containers is not None:
-            params['include_containers'] = str(include_containers)
         if container_type:
             params['container_type'] = container_type
-        if index_by:
-            params['index_by'] = index_by
 
-        url = self._make_url() + '/toolbox'
+        url = '/'.join((self._make_url(), 'toolbox'))
         return self._get(url=url, params=params)

--- a/bioblend/galaxy/tool_dependencies/__init__.py
+++ b/bioblend/galaxy/tool_dependencies/__init__.py
@@ -14,7 +14,7 @@ class ToolDependenciesClient(Client):
         """
         GET /api/dependency_resolvers/toolbox
 
-        Summarize requirements across toolbox (for Tool Management grid). This is an experiemental
+        Summarize requirements across toolbox (for Tool Management grid). This is an experimental
         API particularly tied to the GUI - expect breaking changes until this notice is removed.
 
         :type index: int

--- a/bioblend/galaxy/tool_dependencies/__init__.py
+++ b/bioblend/galaxy/tool_dependencies/__init__.py
@@ -1,5 +1,5 @@
 """
-Contains possible interaction dealing with Galaxy dependency resolvers.
+Contains interactions dealing with Galaxy dependency resolvers.
 """
 from bioblend.galaxy.client import Client
 
@@ -14,6 +14,9 @@ class ToolDependenciesClient(Client):
         """
         Summarize requirements across toolbox (for Tool Management grid). This is an experimental
         API particularly tied to the GUI - expect breaking changes until this notice is removed.
+ 
+        This API endpoint is available on Galaxy version 20.01 or later.
+        This functionality is available only to Galaxy admins.
 
         :type index: int
         :param index: index of the dependency resolver

--- a/bioblend/galaxy/tool_dependencies/__init__.py
+++ b/bioblend/galaxy/tool_dependencies/__init__.py
@@ -14,7 +14,7 @@ class ToolDependenciesClient(Client):
         """
         Summarize requirements across toolbox (for Tool Management grid). This is an experimental
         API particularly tied to the GUI - expect breaking changes until this notice is removed.
- 
+
         This API endpoint is available on Galaxy version 20.01 or later.
         This functionality is available only to Galaxy admins.
 


### PR DESCRIPTION
Add file for ToolDependencies API with a function `summarize_toolbox` plus a test file.

https://docs.galaxyproject.org/en/master/api/api.html#module-galaxy.webapps.galaxy.api.tool_dependencies