### PR TITLE
Improve coverage of the jobs API

### DIFF
--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -143,6 +143,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         self.assertIn('Runner Job ID', response)
         self.assertIn('Handler', response)
 
+    @test_util.skip_unless_galaxy('release_18.01')
     @test_util.skip_unless_tool("random_lines1")
     def test_search_jobs(self):
         tool_id = 'random_lines1'

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -133,6 +133,11 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         self.assertEqual(history_contents[1]['state'], 'error')
         self.assertEqual(history_contents[2]['state'], 'paused')
 
+        # resume the paused step job
+        self.gi.jobs.resume_job(job_steps[-1]['job_id'])
+        history_contents_resumed = self.gi.histories.show_history(self.history_id, contents=True)
+        self.assertNotEqual(history_contents_resumed[2]['state'], 'paused')
+
         # now rerun and remap with correct input param
         job_id = self.gi.datasets.show_dataset(history_contents[1]['id'])['creating_job']
         tool_inputs_update = {
@@ -164,13 +169,6 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     def test_get_outputs(self):
         job_id, output_id = self._run_tool()
         response: dict = self.gi.jobs.get_outputs(job_id)
-        self.assertEqual(response, [{'name': 'out_file1', 'dataset': {'src': 'hda', 'id': output_id}}])
-
-    @test_util.skip_unless_galaxy('release_18.09')
-    @test_util.skip_unless_tool("random_lines1")
-    def test_resume_job(self):
-        job_id, output_id = self._run_tool()
-        response: dict = self.gi.jobs.resume_job(job_id)
         self.assertEqual(response, [{'name': 'out_file1', 'dataset': {'src': 'hda', 'id': output_id}}])
 
     @test_util.skip_unless_galaxy('release_20.05')

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -58,7 +58,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     @test_util.skip_unless_galaxy('release_21.01')
     @test_util.skip_unless_tool("random_lines1")
     def test_run_and_rerun_random_lines(self):
-        original_output = self._run_tool()
+        original_output = self._run_tool(input_format='21.01')
         original_job_id = original_output['jobs'][0]['id']
 
         rerun_output = self.gi.jobs.rerun_job(original_job_id)
@@ -180,22 +180,27 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         status = self.gi.jobs.update_job_lock(active=False)
         self.assertFalse(status)
 
-    def _run_tool(self, tool_id='random_lines1') -> dict:
+    def _run_tool(self, tool_id: str = 'random_lines1', input_format: str = 'legacy') -> dict:
         tool_inputs = {
             'num_lines': '1',
             'input': {
                 'src': 'hda',
                 'id': self.dataset_id
             },
+            # include both input formats so that either can be specified to run_tool()
+            # 21.01 format
             'seed_source': {
                 'seed_source_selector': 'set_seed',
                 'seed': 'asdf'
-            }
+            },
+            # legacy format
+            'seed_source|seed_source_selector': 'set_seed',
+            'seed_source|seed': 'asdf'
         }
 
         return self.gi.tools.run_tool(
             history_id=self.history_id,
             tool_id=tool_id,
             tool_inputs=tool_inputs,
-            input_format='21.01'
+            input_format=input_format
         )

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -156,7 +156,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
             'seed_source|seed_source_selector': 'set_seed',
             'seed_source|seed': 'asdf'
         }
-        response = self.gi.jobs.search_jobs({'tool_id': 'random_lines1', 'inputs': inputs})
+        response = self.gi.jobs.search_jobs('random_lines1', inputs)
         self.assertIn(job_id, [job['id'] for job in response])
 
     @test_util.skip_unless_galaxy('release_20.01')

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -178,7 +178,9 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     def test_get_destination_params(self):
         job_id, _ = self._run_tool()
         response: dict = self.gi.jobs.get_destination_params(job_id)
-        self.assertEqual(response, {'Runner': None, 'Runner Job ID': None, 'Handler': 'main'})
+        self.assertIn('Runner', response)
+        self.assertIn('Runner Job ID', response)
+        self.assertIn('Handler', response)
 
     @test_util.skip_unless_tool("random_lines1")
     def test_search_jobs(self):

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -118,27 +118,27 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     @test_util.skip_unless_tool("random_lines1")
     def test_get_common_problems(self):
         job_id = self._run_tool()['jobs'][0]['id']
-        response: dict = self.gi.jobs.get_common_problems(job_id)
+        response = self.gi.jobs.get_common_problems(job_id)
         self.assertEqual(response, {'has_duplicate_inputs': False, 'has_empty_inputs': True})
 
     @test_util.skip_unless_tool("random_lines1")
     def test_get_inputs(self):
         job_id = self._run_tool()['jobs'][0]['id']
-        response: dict = self.gi.jobs.get_inputs(job_id)
+        response = self.gi.jobs.get_inputs(job_id)
         self.assertEqual(response, [{'name': 'input', 'dataset': {'src': 'hda', 'id': self.dataset_id}}])
 
     @test_util.skip_unless_tool("random_lines1")
     def test_get_outputs(self):
         output = self._run_tool()
         job_id, output_id = output['jobs'][0]['id'], output['outputs'][0]['id']
-        response: dict = self.gi.jobs.get_outputs(job_id)
+        response = self.gi.jobs.get_outputs(job_id)
         self.assertEqual(response, [{'name': 'out_file1', 'dataset': {'src': 'hda', 'id': output_id}}])
 
     @test_util.skip_unless_galaxy('release_20.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_get_destination_params(self):
         job_id = self._run_tool()['jobs'][0]['id']
-        response: dict = self.gi.jobs.get_destination_params(job_id)
+        response = self.gi.jobs.get_destination_params(job_id)
         self.assertIn('Runner', response)
         self.assertIn('Runner Job ID', response)
         self.assertIn('Handler', response)
@@ -156,7 +156,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
             'seed_source|seed_source_selector': 'set_seed',
             'seed_source|seed': 'asdf'
         }
-        response: dict = self.gi.jobs.search_jobs({'tool_id': 'random_lines1', 'inputs': inputs})
+        response = self.gi.jobs.search_jobs({'tool_id': 'random_lines1', 'inputs': inputs})
         self.assertIn(job_id, [job['id'] for job in response])
 
     @test_util.skip_unless_galaxy('release_20.01')
@@ -164,7 +164,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     def test_report_error(self):
         output = self._run_tool()
         job_id, output_id = output['jobs'][0]['id'], output['outputs'][0]['id']
-        response: dict = self.gi.jobs.report_error(job_id, output_id, 'Test error')
+        response = self.gi.jobs.report_error(job_id, output_id, 'Test error')
         # expected response when the Galaxy server does not have mail configured
         self.assertEqual(response, {'messages': [['An error occurred sending the report by email: Mail is not configured for this Galaxy instance', 'danger']]})
 

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -146,3 +146,88 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         self.assertEqual(last_dataset['hid'], 3)
         self.assertEqual(last_dataset['id'], history_contents[2]['id'])
         self._wait_and_verify_dataset(last_dataset['id'], b'line 1\tline 1\n')
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_tool("random_lines1")
+    def test_get_common_problems(self):
+        job_id, _ = self._run_tool()
+        response: dict = self.gi.jobs.get_common_problems(job_id)
+        self.assertEqual(response, {'has_duplicate_inputs': False, 'has_empty_inputs': True})
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_tool("random_lines1")
+    def test_get_inputs(self):
+        job_id, _ = self._run_tool()
+        response: dict = self.gi.jobs.get_inputs(job_id)
+        self.assertEqual(response, [{'name': 'input', 'dataset': {'src': 'hda', 'id': self.dataset_id}}])
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_tool("random_lines1")
+    def test_get_outputs(self):
+        job_id, output_id = self._run_tool()
+        response: dict = self.gi.jobs.get_outputs(job_id)
+        self.assertEqual(response, [{'name': 'out_file1', 'dataset': {'src': 'hda', 'id': output_id}}])
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_tool("random_lines1")
+    def test_resume_job(self):
+        job_id, output_id = self._run_tool()
+        response: dict = self.gi.jobs.resume_job(job_id)
+        self.assertEqual(response, [{'name': 'out_file1', 'dataset': {'src': 'hda', 'id': output_id}}])
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_tool("random_lines1")
+    def test_get_destination_params(self):
+        job_id, _ = self._run_tool()
+        response: dict = self.gi.jobs.get_destination_params(job_id)
+        self.assertEqual(response, {'Runner': None, 'Runner Job ID': None, 'Handler': 'main'})
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_tool("random_lines1")
+    def test_search_jobs(self):
+        tool_id = 'random_lines1'
+        job_id, _ = self._run_tool(tool_id=tool_id)
+        response: dict = self.gi.jobs.search_jobs({'tool_id': tool_id, 'inputs': self.gi.jobs.get_inputs(job_id)[0]})
+        self.assertEqual(response, [])
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_tool("random_lines1")
+    def test_report_error(self):
+        job_id, output_id = self._run_tool()
+        response: dict = self.gi.jobs.report_error(job_id, output_id, 'Test error')
+        # expected response when the Galaxy server does not have mail configured
+        self.assertEqual(response, {'messages': [['An error occurred sending the report by email: Mail is not configured for this Galaxy instance', 'danger']]})
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    def test_show_job_lock(self):
+        status = self.gi.jobs.show_job_lock()
+        self.assertFalse(status)
+
+    @test_util.skip_unless_galaxy('release_21.05')
+    def test_update_job_lock(self):
+        status = self.gi.jobs.update_job_lock(active=True)
+        self.assertTrue(status)
+        status = self.gi.jobs.update_job_lock(active=False)
+        self.assertFalse(status)
+
+    def _run_tool(self, tool_id='random_lines1') -> (str, str):
+        tool_inputs = {
+            'num_lines': '1',
+            'input': {
+                'src': 'hda',
+                'id': self.dataset_id
+            },
+            'seed_source': {
+                'seed_source_selector': 'set_seed',
+                'seed': 'asdf'
+            }
+        }
+
+        output = self.gi.tools.run_tool(
+            history_id=self.history_id,
+            tool_id=tool_id,
+            tool_inputs=tool_inputs,
+            input_format='21.01'
+        )
+        print(output)
+        return output['jobs'][0]['id'], output['outputs'][0]['id']

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -189,6 +189,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         response: dict = self.gi.jobs.search_jobs({'tool_id': tool_id, 'inputs': self.gi.jobs.get_inputs(job_id)[0]})
         self.assertEqual(response, [])
 
+    @test_util.skip_unless_galaxy('release_20.01')
     @test_util.skip_unless_tool("random_lines1")
     def test_report_error(self):
         job_id, output_id = self._run_tool()

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -184,8 +184,17 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     def test_search_jobs(self):
         tool_id = 'random_lines1'
         job_id, _ = self._run_tool(tool_id=tool_id)
-        response: dict = self.gi.jobs.search_jobs({'tool_id': tool_id, 'inputs': self.gi.jobs.get_inputs(job_id)[0]})
-        self.assertEqual(response, [])
+        inputs = {
+            'num_lines': '1',
+            'input': {
+                'src': 'hda',
+                'id': self.dataset_id
+            },
+            'seed_source|seed_source_selector': 'set_seed',
+            'seed_source|seed': 'asdf'
+        }
+        response: dict = self.gi.jobs.search_jobs({'tool_id': tool_id, 'inputs': inputs})
+        self.assertIn(job_id, [job['id'] for job in response])
 
     @test_util.skip_unless_galaxy('release_20.01')
     @test_util.skip_unless_tool("random_lines1")

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -146,8 +146,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     @test_util.skip_unless_galaxy('release_18.01')
     @test_util.skip_unless_tool("random_lines1")
     def test_search_jobs(self):
-        tool_id = 'random_lines1'
-        job_id = self._run_tool(tool_id=tool_id)['jobs'][0]['id']
+        job_id = self._run_tool()['jobs'][0]['id']
         inputs = {
             'num_lines': '1',
             'input': {
@@ -157,7 +156,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
             'seed_source|seed_source_selector': 'set_seed',
             'seed_source|seed': 'asdf'
         }
-        response: dict = self.gi.jobs.search_jobs({'tool_id': tool_id, 'inputs': inputs})
+        response: dict = self.gi.jobs.search_jobs({'tool_id': 'random_lines1', 'inputs': inputs})
         self.assertIn(job_id, [job['id'] for job in response])
 
     @test_util.skip_unless_galaxy('release_20.01')
@@ -181,30 +180,31 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         status = self.gi.jobs.update_job_lock(active=False)
         self.assertFalse(status)
 
-    def _run_tool(self, tool_id: str = 'random_lines1', input_format: str = 'legacy') -> dict:
+    def _run_tool(self, input_format: str = 'legacy') -> dict:
         tool_inputs = {
             'num_lines': '1',
             'input': {
                 'src': 'hda',
                 'id': self.dataset_id
             },
-            # use either the legacy or the 21.01 input format
-            **({
-                # 21.01 format
+        }
+        if input_format == '21.01':
+            tool_inputs.update({
                 'seed_source': {
                     'seed_source_selector': 'set_seed',
                     'seed': 'asdf'
                 }
-            } if input_format == '21.01' else {
-                # legacy format
+            })
+        else:
+            # legacy format
+            tool_inputs.update({
                 'seed_source|seed_source_selector': 'set_seed',
                 'seed_source|seed': 'asdf'
             })
-        }
 
         return self.gi.tools.run_tool(
             history_id=self.history_id,
-            tool_id=tool_id,
+            tool_id='random_lines1',
             tool_inputs=tool_inputs,
             input_format=input_format
         )

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -228,5 +228,4 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
             tool_inputs=tool_inputs,
             input_format='21.01'
         )
-        print(output)
         return output['jobs'][0]['id'], output['outputs'][0]['id']

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -188,15 +188,18 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
                 'src': 'hda',
                 'id': self.dataset_id
             },
-            # include both input formats so that either can be specified to run_tool()
-            # 21.01 format
-            'seed_source': {
-                'seed_source_selector': 'set_seed',
-                'seed': 'asdf'
-            },
-            # legacy format
-            'seed_source|seed_source_selector': 'set_seed',
-            'seed_source|seed': 'asdf'
+            # use either the legacy or the 21.01 input format
+            **({
+                # 21.01 format
+                'seed_source': {
+                    'seed_source_selector': 'set_seed',
+                    'seed': 'asdf'
+                }
+            } if input_format == '21.01' else {
+                # legacy format
+                'seed_source|seed_source_selector': 'set_seed',
+                'seed_source|seed': 'asdf'
+            })
         }
 
         return self.gi.tools.run_tool(

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -147,42 +147,39 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         self.assertEqual(last_dataset['id'], history_contents[2]['id'])
         self._wait_and_verify_dataset(last_dataset['id'], b'line 1\tline 1\n')
 
-    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_galaxy('release_19.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_get_common_problems(self):
         job_id, _ = self._run_tool()
         response: dict = self.gi.jobs.get_common_problems(job_id)
         self.assertEqual(response, {'has_duplicate_inputs': False, 'has_empty_inputs': True})
 
-    @test_util.skip_unless_galaxy('release_21.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_get_inputs(self):
         job_id, _ = self._run_tool()
         response: dict = self.gi.jobs.get_inputs(job_id)
         self.assertEqual(response, [{'name': 'input', 'dataset': {'src': 'hda', 'id': self.dataset_id}}])
 
-    @test_util.skip_unless_galaxy('release_21.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_get_outputs(self):
         job_id, output_id = self._run_tool()
         response: dict = self.gi.jobs.get_outputs(job_id)
         self.assertEqual(response, [{'name': 'out_file1', 'dataset': {'src': 'hda', 'id': output_id}}])
 
-    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_galaxy('release_18.09')
     @test_util.skip_unless_tool("random_lines1")
     def test_resume_job(self):
         job_id, output_id = self._run_tool()
         response: dict = self.gi.jobs.resume_job(job_id)
         self.assertEqual(response, [{'name': 'out_file1', 'dataset': {'src': 'hda', 'id': output_id}}])
 
-    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_galaxy('release_20.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_get_destination_params(self):
         job_id, _ = self._run_tool()
         response: dict = self.gi.jobs.get_destination_params(job_id)
         self.assertEqual(response, {'Runner': None, 'Runner Job ID': None, 'Handler': 'main'})
 
-    @test_util.skip_unless_galaxy('release_21.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_search_jobs(self):
         tool_id = 'random_lines1'
@@ -190,7 +187,6 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         response: dict = self.gi.jobs.search_jobs({'tool_id': tool_id, 'inputs': self.gi.jobs.get_inputs(job_id)[0]})
         self.assertEqual(response, [])
 
-    @test_util.skip_unless_galaxy('release_21.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_report_error(self):
         job_id, output_id = self._run_tool()
@@ -198,12 +194,12 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         # expected response when the Galaxy server does not have mail configured
         self.assertEqual(response, {'messages': [['An error occurred sending the report by email: Mail is not configured for this Galaxy instance', 'danger']]})
 
-    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_galaxy('release_20.05')
     def test_show_job_lock(self):
         status = self.gi.jobs.show_job_lock()
         self.assertFalse(status)
 
-    @test_util.skip_unless_galaxy('release_21.05')
+    @test_util.skip_unless_galaxy('release_20.05')
     def test_update_job_lock(self):
         status = self.gi.jobs.update_job_lock(active=True)
         self.assertTrue(status)

--- a/bioblend/_tests/TestGalaxyJobs.py
+++ b/bioblend/_tests/TestGalaxyJobs.py
@@ -39,29 +39,8 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
 
     @test_util.skip_unless_tool("random_lines1")
     def test_get_jobs(self):
-        tool_inputs = {
-            'num_lines': '1',
-            'input': {
-                'src': 'hda',
-                'id': self.dataset_id
-            },
-            'seed_source': {
-                'seed_source_selector': 'set_seed',
-                'seed': 'asdf'
-            }
-        }
-        self.gi.tools.run_tool(
-            history_id=self.history_id,
-            tool_id="random_lines1",
-            tool_inputs=tool_inputs,
-            input_format='21.01'
-        )
-        self.gi.tools.run_tool(
-            history_id=self.history_id,
-            tool_id="random_lines1",
-            tool_inputs=tool_inputs,
-            input_format='21.01'
-        )
+        self._run_tool()
+        self._run_tool()
 
         jobs = self.gi.jobs.get_jobs(tool_id='random_lines1', history_id=self.history_id)
         self.assertEqual(len(jobs), 2)
@@ -79,24 +58,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     @test_util.skip_unless_galaxy('release_21.01')
     @test_util.skip_unless_tool("random_lines1")
     def test_run_and_rerun_random_lines(self):
-        tool_inputs = {
-            'num_lines': '1',
-            'input': {
-                'src': 'hda',
-                'id': self.dataset_id
-            },
-            'seed_source': {
-                'seed_source_selector': 'set_seed',
-                'seed': 'asdf'
-            }
-        }
-
-        original_output = self.gi.tools.run_tool(
-            history_id=self.history_id,
-            tool_id="random_lines1",
-            tool_inputs=tool_inputs,
-            input_format='21.01'
-        )
+        original_output = self._run_tool()
         original_job_id = original_output['jobs'][0]['id']
 
         rerun_output = self.gi.jobs.rerun_job(original_job_id)
@@ -155,26 +117,27 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     @test_util.skip_unless_galaxy('release_19.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_get_common_problems(self):
-        job_id, _ = self._run_tool()
+        job_id = self._run_tool()['jobs'][0]['id']
         response: dict = self.gi.jobs.get_common_problems(job_id)
         self.assertEqual(response, {'has_duplicate_inputs': False, 'has_empty_inputs': True})
 
     @test_util.skip_unless_tool("random_lines1")
     def test_get_inputs(self):
-        job_id, _ = self._run_tool()
+        job_id = self._run_tool()['jobs'][0]['id']
         response: dict = self.gi.jobs.get_inputs(job_id)
         self.assertEqual(response, [{'name': 'input', 'dataset': {'src': 'hda', 'id': self.dataset_id}}])
 
     @test_util.skip_unless_tool("random_lines1")
     def test_get_outputs(self):
-        job_id, output_id = self._run_tool()
+        output = self._run_tool()
+        job_id, output_id = output['jobs'][0]['id'], output['outputs'][0]['id']
         response: dict = self.gi.jobs.get_outputs(job_id)
         self.assertEqual(response, [{'name': 'out_file1', 'dataset': {'src': 'hda', 'id': output_id}}])
 
     @test_util.skip_unless_galaxy('release_20.05')
     @test_util.skip_unless_tool("random_lines1")
     def test_get_destination_params(self):
-        job_id, _ = self._run_tool()
+        job_id = self._run_tool()['jobs'][0]['id']
         response: dict = self.gi.jobs.get_destination_params(job_id)
         self.assertIn('Runner', response)
         self.assertIn('Runner Job ID', response)
@@ -183,7 +146,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     @test_util.skip_unless_tool("random_lines1")
     def test_search_jobs(self):
         tool_id = 'random_lines1'
-        job_id, _ = self._run_tool(tool_id=tool_id)
+        job_id = self._run_tool(tool_id=tool_id)['jobs'][0]['id']
         inputs = {
             'num_lines': '1',
             'input': {
@@ -199,7 +162,8 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
     @test_util.skip_unless_galaxy('release_20.01')
     @test_util.skip_unless_tool("random_lines1")
     def test_report_error(self):
-        job_id, output_id = self._run_tool()
+        output = self._run_tool()
+        job_id, output_id = output['jobs'][0]['id'], output['outputs'][0]['id']
         response: dict = self.gi.jobs.report_error(job_id, output_id, 'Test error')
         # expected response when the Galaxy server does not have mail configured
         self.assertEqual(response, {'messages': [['An error occurred sending the report by email: Mail is not configured for this Galaxy instance', 'danger']]})
@@ -216,7 +180,7 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
         status = self.gi.jobs.update_job_lock(active=False)
         self.assertFalse(status)
 
-    def _run_tool(self, tool_id='random_lines1') -> (str, str):
+    def _run_tool(self, tool_id='random_lines1') -> dict:
         tool_inputs = {
             'num_lines': '1',
             'input': {
@@ -229,10 +193,9 @@ class TestGalaxyJobs(GalaxyTestBase.GalaxyTestBase):
             }
         }
 
-        output = self.gi.tools.run_tool(
+        return self.gi.tools.run_tool(
             history_id=self.history_id,
             tool_id=tool_id,
             tool_inputs=tool_inputs,
             input_format='21.01'
         )
-        return output['jobs'][0]['id'], output['outputs'][0]['id']

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -234,7 +234,7 @@ class JobsClient(Client):
 
     def search_jobs(self, tool_id: str, inputs: dict, state: Optional[str] = None) -> List[dict]:
         """
-        Return jobs matching input parameters specified in ``job_info``.
+        Return jobs matching input parameters.
 
         :type tool_id: str
         :param tool_id: only return jobs associated with this tool ID

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -3,6 +3,7 @@ Contains possible interactions with the Galaxy Jobs
 """
 import logging
 import time
+from typing import List
 
 from bioblend import TimeoutException
 from bioblend.galaxy.client import Client
@@ -196,7 +197,7 @@ class JobsClient(Client):
         """
         return self.show_job(job_id).get('state', '')
 
-    def search_jobs(self, job_info: dict) -> list:
+    def search_jobs(self, tool_inputs: dict) -> List[dict]:
         """
         Return jobs matching input parameters specified in ``job_info``.
 
@@ -220,7 +221,7 @@ class JobsClient(Client):
         url = self._make_url() + '/search'
         return self._post(url=url, payload=job_info)
 
-    def get_metrics(self, job_id: str) -> list:
+    def get_metrics(self, job_id: str) -> List[dict]:
         """
         Return job metrics for a given job.
 
@@ -290,7 +291,7 @@ class JobsClient(Client):
         url = self._make_url(module_id=job_id) + '/common_problems'
         return self._get(url=url)
 
-    def get_inputs(self, job_id: str) -> dict:
+    def get_inputs(self, job_id: str) -> List[dict]:
         """
         Get dataset inputs used by a job.
 
@@ -303,7 +304,7 @@ class JobsClient(Client):
         url = self._make_url(module_id=job_id) + '/inputs'
         return self._get(url=url)
 
-    def get_outputs(self, job_id: str) -> dict:
+    def get_outputs(self, job_id: str) -> List[dict]:
         """
         Get dataset outputs produced by a job.
 

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -262,7 +262,7 @@ class JobsClient(Client):
         :return: dict containing job error reply
 
         .. note::
-          This method only supports in Galaxy 20.01 or later.
+          This method only supports Galaxy 20.01 or later.
         """
         payload = {
             "message": message,
@@ -286,7 +286,7 @@ class JobsClient(Client):
         :return: dict containing potential problems
 
         .. note::
-          This method only supports in Galaxy 19.05 or later.
+          This method only supports Galaxy 19.05 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/common_problems'
         return self._get(url=url)
@@ -328,7 +328,7 @@ class JobsClient(Client):
         :return: dict containing output dataset associations
 
         .. note::
-          This method only supports in Galaxy 18.09 or later.
+          This method only supports Galaxy 18.09 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/resume'
         return self._put(url=url, payload={})
@@ -345,7 +345,7 @@ class JobsClient(Client):
         :return: dict containing destination params
 
         .. note::
-          This method only supports in Galaxy 20.05 or later.
+          This method only supports Galaxy 20.05 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/destination_params'
         return self._get(url=url)
@@ -362,7 +362,7 @@ class JobsClient(Client):
           This method can only be used by admin users.
 
         .. note::
-          This method only supports in Galaxy 20.05 or later.
+          This method only supports Galaxy 20.05 or later.
         """
         url: str = self.gi.url + '/job_lock'
         response: dict = self._get(url=url)
@@ -381,7 +381,7 @@ class JobsClient(Client):
           This method can only be used by admin users.
 
         .. note::
-          This method only supports in Galaxy 20.05 or later.
+          This method only supports Galaxy 20.05 or later.
         """
         payload = {
             'active': active,

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -214,6 +214,8 @@ class JobsClient(Client):
         be used to minimize the amount of repeated work by simply recycling the
         old results.
 
+        .. note::
+          This method is only available in Galaxy 18.01 or later.
         """
 
         url = self._make_url() + '/search'
@@ -258,6 +260,9 @@ class JobsClient(Client):
 
         :rtype: dict
         :return: dict containing job error reply
+
+        .. note::
+          This method is only available in Galaxy 20.01 or later.
         """
         payload = {
             "message": message,
@@ -279,6 +284,9 @@ class JobsClient(Client):
 
         :rtype: dict
         :return: dict containing potential problems
+
+        .. note::
+          This method is only available in Galaxy 19.05 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/common_problems'
         return self._get(url=url)
@@ -318,6 +326,9 @@ class JobsClient(Client):
 
         :rtype: dict
         :return: dict containing output dataset associations
+
+        .. note::
+          This method is only available in Galaxy 18.09 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/resume'
         return self._put(url=url, payload={})
@@ -332,6 +343,9 @@ class JobsClient(Client):
 
         :rtype: dict
         :return: dict containing destination params
+
+        .. note::
+          This method is only available in Galaxy 20.05 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/destination_params'
         return self._get(url=url)
@@ -346,6 +360,9 @@ class JobsClient(Client):
 
         .. note::
           This method can only be used by admin users.
+
+        .. note::
+          This method is only available in Galaxy 20.05 or later.
         """
         url: str = self.gi.url + '/job_lock'
         response: dict = self._get(url=url)
@@ -362,6 +379,9 @@ class JobsClient(Client):
 
         .. note::
           This method can only be used by admin users.
+
+        .. note::
+          This method is only available in Galaxy 20.05 or later.
         """
         payload = {
             'active': active,

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -217,6 +217,10 @@ class JobsClient(Client):
         be used to minimize the amount of repeated work by simply recycling the
         old results.
 
+        .. versionchanged:: 0.16.0
+          Replaced the ``job_info`` parameter with separate ``tool_id``,
+          ``inputs`` and ``state``.
+
         .. note::
           This method is only supported by Galaxy 18.01 or later.
         """

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -180,7 +180,7 @@ class JobsClient(Client):
         }
         return self._post(url=url, payload=payload)
 
-    def get_state(self, job_id):
+    def get_state(self, job_id: str) -> str:
         """
         Display the current state for a given job of the current user.
 
@@ -196,7 +196,7 @@ class JobsClient(Client):
         """
         return self.show_job(job_id).get('state', '')
 
-    def search_jobs(self, job_info):
+    def search_jobs(self, job_info: dict) -> list:
         """
         Return jobs for the current user based payload content.
 
@@ -220,7 +220,7 @@ class JobsClient(Client):
         url = self._make_url() + '/search'
         return self._post(url=url, payload=payload)
 
-    def get_metrics(self, job_id):
+    def get_metrics(self, job_id: str) -> list:
         """
         Return job metrics for a given job.
 
@@ -240,7 +240,7 @@ class JobsClient(Client):
         url = self._make_url(module_id=job_id) + '/metrics'
         return self._get(url=url)
 
-    def report_error(self, job_id, dataset_id, message, email=None):
+    def report_error(self, job_id: str, dataset_id: str, message: str, email=None) -> dict:
         """
         Report an error for a given job and dataset.
 
@@ -268,6 +268,97 @@ class JobsClient(Client):
 
         url = self._make_url(module_id=job_id) + '/error'
         return self._post(url=url, payload=payload)
+
+    def get_common_problems(self, job_id: str) -> dict:
+        """
+        Query inputs and jobs for common potential problems.
+
+        :type job_id: str
+        :param job_id: job ID
+
+        :rtype: dict
+        :return: dict containing potential problems
+        """
+        url: str = self._make_url(module_id=job_id) + '/common_problems'
+        return self._get(url=url)
+
+    def get_inputs(self, job_id: str) -> dict:
+        """
+        Get inputs for a specific job ID.
+
+        :type job_id: str
+        :param job_id: job ID
+
+        :rtype: dict
+        :return: dict containing inputs for this job ID
+        """
+        url: str = self._make_url(module_id=job_id) + '/inputs'
+        return self._get(url=url)
+
+    def get_outputs(self, job_id: str) -> dict:
+        """
+        Get outputs for a specific job ID.
+
+        :type job_id: str
+        :param job_id: job ID
+
+        :rtype: dict
+        :return: dict containing outputs for this job ID
+        """
+        url: str = self._make_url(module_id=job_id) + '/outputs'
+        return self._get(url=url)
+
+    def resume_job(self, job_id: str) -> dict:
+        """
+        Resume a job if it is paused.
+
+        :type job_id: str
+        :param job_id: job ID
+
+        :rtype: dict
+        :return: dict containing output dataset associations
+        """
+        payload = {}
+        url: str = self._make_url(module_id=job_id) + '/resume'
+        return self._put(url=url, payload=payload)
+
+    def get_destination_params(self, job_id: str) -> dict:
+        """
+        Get destination parameters for the specific job ID.
+
+        :type job_id: str
+        :param job_id: job ID
+
+        :rtype: dict
+        :return: dict containing destination params
+        """
+        url: str = self._make_url(module_id=job_id) + '/destination_params'
+        return self._get(url=url)
+
+    def show_job_lock(self) -> bool:
+        """
+        Show whether the job lock is active or not.
+
+        :rtype: bool
+        :return: boolean indication the status of the job lock
+        """
+        url: str = self.gi.url + '/job_lock'
+        response: dict = self._get(url=url)
+        return response['active']
+
+    def update_job_lock(self, active=False) -> dict:
+        """
+        Update the job lock status: active or inactive
+
+        :rtype: bool
+        :return: boolean indication the status of the job lock
+        """
+        payload = {
+            'active': active,
+        }
+        url: str = self.gi.url + '/job_lock'
+        response: dict = self._put(url=url, payload=payload)
+        return response['active']
 
     def wait_for_job(self, job_id, maxwait=12000, interval=3, check=True):
         """

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -197,7 +197,7 @@ class JobsClient(Client):
         """
         return self.show_job(job_id).get('state', '')
 
-    def search_jobs(self, tool_inputs: dict) -> List[dict]:
+    def search_jobs(self, job_info: dict) -> List[dict]:
         """
         Return jobs matching input parameters specified in ``job_info``.
 

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -205,9 +205,8 @@ class JobsClient(Client):
           the same way as the ``tool_inputs`` parameter of the ``gi.tools.run_tool()``
           method.
 
-        :rtype: list
-        :return: list of dictionaries containing summary job information of
-          the jobs that match the requested job run
+        :rtype: list of dicts
+        :return: Summary information for each matching job
 
         This method is designed to scan the list of previously run jobs and find
         records of jobs with identical input parameters and datasets. This can
@@ -215,7 +214,7 @@ class JobsClient(Client):
         old results.
 
         .. note::
-          This method only supports Galaxy 18.01 or later.
+          This method is only supported by Galaxy 18.01 or later.
         """
 
         url = self._make_url() + '/search'
@@ -241,7 +240,7 @@ class JobsClient(Client):
         url = self._make_url(module_id=job_id) + '/metrics'
         return self._get(url=url)
 
-    def report_error(self, job_id: str, dataset_id: str, message: str, email=None) -> dict:
+    def report_error(self, job_id: str, dataset_id: str, message: str, email: str = None) -> dict:
         """
         Report an error for a given job and dataset to the server administrators.
 
@@ -262,7 +261,7 @@ class JobsClient(Client):
         :return: dict containing job error reply
 
         .. note::
-          This method only supports Galaxy 20.01 or later.
+          This method is only supported by Galaxy 20.01 or later.
         """
         payload = {
             "message": message,
@@ -286,35 +285,35 @@ class JobsClient(Client):
         :return: dict containing potential problems
 
         .. note::
-          This method only supports Galaxy 19.05 or later.
+          This method is only supported by Galaxy 19.05 or later.
         """
-        url: str = self._make_url(module_id=job_id) + '/common_problems'
+        url = self._make_url(module_id=job_id) + '/common_problems'
         return self._get(url=url)
 
     def get_inputs(self, job_id: str) -> dict:
         """
-        Get dataset inputs used by a specific job ID.
+        Get dataset inputs used by a job.
 
         :type job_id: str
         :param job_id: job ID
 
-        :rtype: dict
-        :return: dict containing inputs for this job ID
+        :rtype: list of dicts
+        :return: Inputs for the given job
         """
-        url: str = self._make_url(module_id=job_id) + '/inputs'
+        url = self._make_url(module_id=job_id) + '/inputs'
         return self._get(url=url)
 
     def get_outputs(self, job_id: str) -> dict:
         """
-        Get dataset outputs produced by a specific job ID.
+        Get dataset outputs produced by a job.
 
         :type job_id: str
         :param job_id: job ID
 
-        :rtype: dict
-        :return: dict containing outputs for this job ID
+        :rtype: list of dicts
+        :return: Outputs of the given job
         """
-        url: str = self._make_url(module_id=job_id) + '/outputs'
+        url = self._make_url(module_id=job_id) + '/outputs'
         return self._get(url=url)
 
     def resume_job(self, job_id: str) -> dict:
@@ -328,26 +327,26 @@ class JobsClient(Client):
         :return: dict containing output dataset associations
 
         .. note::
-          This method only supports Galaxy 18.09 or later.
+          This method is only supported by Galaxy 18.09 or later.
         """
-        url: str = self._make_url(module_id=job_id) + '/resume'
+        url = self._make_url(module_id=job_id) + '/resume'
         return self._put(url=url, payload={})
 
     def get_destination_params(self, job_id: str) -> dict:
         """
-        Get destination parameters for the specific job ID, describing
+        Get destination parameters for a job, describing
         the environment and location where the job is run.
 
         :type job_id: str
         :param job_id: job ID
 
         :rtype: dict
-        :return: dict containing destination params
+        :return: Destination parameters for the given job
 
         .. note::
-          This method only supports Galaxy 20.05 or later.
+          This method is only supported by Galaxy 20.05 or later.
         """
-        url: str = self._make_url(module_id=job_id) + '/destination_params'
+        url = self._make_url(module_id=job_id) + '/destination_params'
         return self._get(url=url)
 
     def show_job_lock(self) -> bool:
@@ -356,38 +355,38 @@ class JobsClient(Client):
         no jobs will dispatch on the Galaxy server.
 
         :rtype: bool
-        :return: boolean indication the status of the job lock
+        :return: Status of the job lock
 
         .. note::
           This method can only be used by admin users.
 
         .. note::
-          This method only supports Galaxy 20.05 or later.
+          This method is only supported by Galaxy 20.05 or later.
         """
-        url: str = self.gi.url + '/job_lock'
-        response: dict = self._get(url=url)
+        url = self.gi.url + '/job_lock'
+        response = self._get(url=url)
         return response['active']
 
-    def update_job_lock(self, active=False) -> dict:
+    def update_job_lock(self, active=False) -> bool:
         """
         Update the job lock status by setting ``active`` to either
         ``True`` or ``False``. If ``True``, all job dispatching will
         be blocked.
 
         :rtype: bool
-        :return: boolean indication the status of the job lock
+        :return: Updated status of the job lock
 
         .. note::
           This method can only be used by admin users.
 
         .. note::
-          This method only supports Galaxy 20.05 or later.
+          This method is only supported by Galaxy 20.05 or later.
         """
         payload = {
             'active': active,
         }
-        url: str = self.gi.url + '/job_lock'
-        response: dict = self._put(url=url, payload=payload)
+        url = self.gi.url + '/job_lock'
+        response = self._put(url=url, payload=payload)
         return response['active']
 
     def wait_for_job(self, job_id, maxwait=12000, interval=3, check=True):

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -393,7 +393,8 @@ class JobsClient(Client):
         :return: Destination parameters for the given job
 
         .. note::
-          This method is only supported by Galaxy 20.05 or later.
+          This method is only supported by Galaxy 20.05 or later and requires
+          the user to be an admin.
         """
         url = self._make_url(module_id=job_id) + '/destination_params'
         return self._get(url=url)
@@ -407,10 +408,8 @@ class JobsClient(Client):
         :return: Status of the job lock
 
         .. note::
-          This method can only be used by admin users.
-
-        .. note::
-          This method is only supported by Galaxy 20.05 or later.
+          This method is only supported by Galaxy 20.05 or later and requires
+          the user to be an admin.
         """
         url = self.gi.url + '/job_lock'
         response = self._get(url=url)
@@ -426,10 +425,8 @@ class JobsClient(Client):
         :return: Updated status of the job lock
 
         .. note::
-          This method can only be used by admin users.
-
-        .. note::
-          This method is only supported by Galaxy 20.05 or later.
+          This method is only supported by Galaxy 20.05 or later and requires
+          the user to be an admin.
         """
         payload = {
             'active': active,

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -236,10 +236,14 @@ class JobsClient(Client):
         """
         Return jobs matching input parameters specified in ``job_info``.
 
-        :type job_info: dict
-        :param job_info: dictionary of input datasets and parameters, formatted in
-          the same way as the ``tool_inputs`` parameter of the ``gi.tools.run_tool()``
-          method.
+        :type tool_id: str
+        :param tool_id: only return jobs associated with this tool ID
+
+        :type inputs: dict
+        :param inputs: return only jobs that have matching inputs
+
+        :type state: str
+        :param state: only return jobs in this state
 
         :rtype: list of dicts
         :return: Summary information for each matching job

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -196,12 +196,12 @@ class JobsClient(Client):
         """
         return self.show_job(job_id).get('state', '')
 
-    def search_jobs(self, tool_inputs: dict) -> list:
+    def search_jobs(self, job_info: dict) -> list:
         """
-        Return jobs matching input parameters specified in ``tool_inputs``.
+        Return jobs matching input parameters specified in ``job_info``.
 
-        :type tool_inputs: dict
-        :param tool_inputs: dictionary of input datasets and parameters, formatted in
+        :type job_info: dict
+        :param job_info: dictionary of input datasets and parameters, formatted in
           the same way as the ``tool_inputs`` parameter of the ``gi.tools.run_tool()``
           method.
 
@@ -219,7 +219,7 @@ class JobsClient(Client):
         """
 
         url = self._make_url() + '/search'
-        return self._post(url=url, payload=tool_inputs)
+        return self._post(url=url, payload=job_info)
 
     def get_metrics(self, job_id: str) -> list:
         """

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -215,7 +215,7 @@ class JobsClient(Client):
         old results.
 
         .. note::
-          This method is only available in Galaxy 18.01 or later.
+          This method only supports Galaxy 18.01 or later.
         """
 
         url = self._make_url() + '/search'
@@ -262,7 +262,7 @@ class JobsClient(Client):
         :return: dict containing job error reply
 
         .. note::
-          This method is only available in Galaxy 20.01 or later.
+          This method only supports in Galaxy 20.01 or later.
         """
         payload = {
             "message": message,
@@ -286,7 +286,7 @@ class JobsClient(Client):
         :return: dict containing potential problems
 
         .. note::
-          This method is only available in Galaxy 19.05 or later.
+          This method only supports in Galaxy 19.05 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/common_problems'
         return self._get(url=url)
@@ -328,7 +328,7 @@ class JobsClient(Client):
         :return: dict containing output dataset associations
 
         .. note::
-          This method is only available in Galaxy 18.09 or later.
+          This method only supports in Galaxy 18.09 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/resume'
         return self._put(url=url, payload={})
@@ -345,7 +345,7 @@ class JobsClient(Client):
         :return: dict containing destination params
 
         .. note::
-          This method is only available in Galaxy 20.05 or later.
+          This method only supports in Galaxy 20.05 or later.
         """
         url: str = self._make_url(module_id=job_id) + '/destination_params'
         return self._get(url=url)
@@ -362,7 +362,7 @@ class JobsClient(Client):
           This method can only be used by admin users.
 
         .. note::
-          This method is only available in Galaxy 20.05 or later.
+          This method only supports in Galaxy 20.05 or later.
         """
         url: str = self.gi.url + '/job_lock'
         response: dict = self._get(url=url)
@@ -381,7 +381,7 @@ class JobsClient(Client):
           This method can only be used by admin users.
 
         .. note::
-          This method is only available in Galaxy 20.05 or later.
+          This method only supports in Galaxy 20.05 or later.
         """
         payload = {
             'active': active,

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -3,7 +3,10 @@ Contains possible interactions with the Galaxy Jobs
 """
 import logging
 import time
-from typing import List
+from typing import (
+    List,
+    Optional,
+)
 
 from bioblend import TimeoutException
 from bioblend.galaxy.client import Client
@@ -197,7 +200,7 @@ class JobsClient(Client):
         """
         return self.show_job(job_id).get('state', '')
 
-    def search_jobs(self, job_info: dict) -> List[dict]:
+    def search_jobs(self, tool_id: str, inputs: dict, state: Optional[str] = None) -> List[dict]:
         """
         Return jobs matching input parameters specified in ``job_info``.
 
@@ -217,7 +220,12 @@ class JobsClient(Client):
         .. note::
           This method is only supported by Galaxy 18.01 or later.
         """
-
+        job_info = {
+            'tool_id': tool_id,
+            'inputs': inputs,
+        }
+        if state:
+            job_info['state'] = state
         url = self._make_url() + '/search'
         return self._post(url=url, payload=job_info)
 


### PR DESCRIPTION
Add the following methods to JobsClient:

- `get_common_problems()`
- `get_inputs()`
- `get_outputs()`
- `resume_job()`
- `get_destination_params()`
- `show_job_lock()`
- `update_job_lock()`

As well as corresponding tests and a helper function `_run_tool()`.