### PR TITLE
Handle HTTPS Cloudman instances better

### DIFF
--- a/bioblend/cloudman/__init__.py
+++ b/bioblend/cloudman/__init__.py
@@ -468,6 +468,10 @@ class CloudManInstance(GenericVMInstance):
         self.vm_error = ms.get('error', None)
         public_ip = ms.get('public_ip', None)
         # Update url if we don't have it or is different than what we have
+        # After _set_url is called, self.url will have a scheme, so
+        # self.url is always different than public_ip. This has the
+        # potential to change the self.url scheme from https to http if
+        # which are not in launch and don't have access to self.config.
         if not self.url and (public_ip and self.url != public_ip):
             self._set_url(public_ip)
         # See if the cluster has been initialized

--- a/bioblend/cloudman/__init__.py
+++ b/bioblend/cloudman/__init__.py
@@ -397,7 +397,7 @@ class CloudManInstance(GenericVMInstance):
             # Make sure the URL scheme is defined (otherwise requests will not work)
             if not url.lower().startswith('http'):
                 # Check the config for use_ssl to see whether https scheme is required
-                if self.config.kwargs.get('use_ssl',False):
+                if self.config.kwargs.get('use_ssl', False):
                     url = "https://" + url
                 else:
                     url = "http://" + url
@@ -728,7 +728,7 @@ class CloudManInstance(GenericVMInstance):
         if parameters is None:
             parameters = {}
         req_url = '/'.join((self.cloudman_url, 'root', url))
-        # need to set the user "ubuntu" for auth, and indicate verify=False for HTTPS 
+        # need to set the user "ubuntu" for auth, and indicate verify=False for HTTPS
         # connections to self-signed certificates
         r = requests.get(req_url, params=parameters, auth=("ubuntu", self.password), timeout=timeout, verify=False)
         try:

--- a/bioblend/cloudman/__init__.py
+++ b/bioblend/cloudman/__init__.py
@@ -729,8 +729,12 @@ class CloudManInstance(GenericVMInstance):
             parameters = {}
         req_url = '/'.join((self.cloudman_url, 'root', url))
         # need to set the user "ubuntu" for auth, and indicate verify=False for HTTPS
-        # connections to self-signed certificates
-        r = requests.get(req_url, params=parameters, auth=("ubuntu", self.password), timeout=timeout, verify=False)
+        # connections to self-signed certificate, avoid adding verify=False unless use_ssl
+        # config is set
+        extrakwargs = {}
+        if self.config.kwargs.get('use_ssl', False):
+            extragetkwargs = { 'verify': False }
+        r = requests.get(req_url, params=parameters, auth=("ubuntu", self.password), timeout=timeout, **extragetkwargs)
         try:
             json = r.json()
             return json

--- a/bioblend/cloudman/launch.py
+++ b/bioblend/cloudman/launch.py
@@ -502,9 +502,13 @@ class CloudManLauncher:
                     # attempt auto allocation of floating IP
                     if rs[0].instances[0].private_ip_address and not public_ip:
                         self.assign_floating_ip(ec2_conn, rs[0].instances[0])
+                    # Wait until the CloudMan URL is accessible to return
+                    # the data - this may only be correct initially at
+                    # bootup for instances that configure themselves for
+                    # https - they may ultimately block port 80. However,
+                    # we don't have a good way to determine whether to
+                    # check using http or https.
                     cm_url = f"http://{public_ip}/cloud"
-                    # Wait until the CloudMan URL is accessible to return the
-                    # data
                     if self._checkURL(cm_url) is True:
                         state['instance_state'] = inst_state
                         state['placement'] = rs[0].instances[0].placement
@@ -859,10 +863,7 @@ class CloudManLauncher:
         """
         try:
             p = urlparse(url)
-            if p.scheme == 'https':
-                h = HTTPSConnection(p[1])
-            else:
-                h = HTTPConnection(p[1])
+            h = HTTPConnection(p[1])
             h.putrequest('HEAD', p[2])
             h.endheaders()
             r = h.getresponse()

--- a/bioblend/cloudman/launch.py
+++ b/bioblend/cloudman/launch.py
@@ -7,7 +7,6 @@ from http.client import (
     BadStatusLine,
     HTTPConnection,
     HTTPException,
-    HTTPSConnection,
 )
 from urllib.parse import urlparse
 

--- a/bioblend/cloudman/launch.py
+++ b/bioblend/cloudman/launch.py
@@ -7,6 +7,7 @@ from http.client import (
     BadStatusLine,
     HTTPConnection,
     HTTPException,
+    HTTPSConnection,
 )
 from urllib.parse import urlparse
 
@@ -858,7 +859,12 @@ class CloudManLauncher:
         """
         try:
             p = urlparse(url)
-            h = HTTPConnection(p[1])
+            if p.scheme == 'http':
+                h = HTTPConnection(p[1])
+            elif p.scheme == 'https':
+                h = HTTPSConnection(p[1])
+            else:
+                raise RuntimeError("Unexpected url scheme: {}".format(p.scheme))
             h.putrequest('HEAD', p[2])
             h.endheaders()
             r = h.getresponse()

--- a/bioblend/cloudman/launch.py
+++ b/bioblend/cloudman/launch.py
@@ -859,12 +859,10 @@ class CloudManLauncher:
         """
         try:
             p = urlparse(url)
-            if p.scheme == 'http':
-                h = HTTPConnection(p[1])
-            elif p.scheme == 'https':
+            if p.scheme == 'https':
                 h = HTTPSConnection(p[1])
             else:
-                raise RuntimeError("Unexpected url scheme: {}".format(p.scheme))
+                h = HTTPConnection(p[1])
             h.putrequest('HEAD', p[2])
             h.endheaders()
             r = h.getresponse()


### PR DESCRIPTION
When starting with configuration option use_ssl True, cloudman must use https to communicate with the instance throughout. Some of the initial setup steps assume only http is needed. 