### PR TITLE
Make `tool_inputs_update` argument of `gi.jobs.rerun_job()` more flexible

### DIFF
--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -185,7 +185,10 @@ class JobsClient(Client):
 
         :type tool_inputs_update: dict
         :param tool_inputs_update: dictionary specifying any changes which should be
-          made to tool parameters for the rerun job.
+          made to tool parameters for the rerun job. This dictionary should have the same
+          structure as is required when submitting the ``tool_inputs`` dictionary to
+          ``gi.tools.run_tool()``, but only needs to include the inputs or parameters
+          to be updated for the rerun job.
 
         :type history_id: str
         :param history_id: ID of the history in which the job should be executed; if
@@ -205,9 +208,18 @@ class JobsClient(Client):
                 raise ValueError('remap was set to True, but this job is not remappable.')
             job_inputs['rerun_remap_job_id'] = job_id
 
-        if tool_inputs_update:
+        def update_inputs(inputs, tool_inputs_update):
+            # recursively update inputs with tool_inputs_update
             for input_param, input_value in tool_inputs_update.items():
-                job_inputs[input_param] = input_value
+                if type(input_value) is dict:
+                    update_inputs(inputs[input_param], input_value)
+                else:
+                    inputs[input_param] = input_value
+            return inputs
+
+        if tool_inputs_update:
+            update_inputs(job_inputs, tool_inputs_update)
+
         url = '/'.join((self.gi.url, 'tools'))
         payload = {
             "history_id": history_id if history_id else job_rerun_params['history_id'],


### PR DESCRIPTION
The `tool_inputs` dictionary which is submitted to run a tool can be quite complicated. Here's an example from the `gmx_sim` tool:
```
{'gro_input': {'values': [{'id': '5c2304bef5249942',
    'src': 'hda'}]},
 'top_input': {'values': [{'id': 'a624b4df4f58d2a8',
    'src': 'hda'}]},
 'inps': {'cpt_in': {'values': [{'id': 'e582474250398d8f',
     'src': 'hda'}]},
  'itp_in': None,
  'ndx_in': {'values': [{'id': '3b4c7a3e3f7b8f6a',
     'src': 'hda'}]}},
 'outps': {'traj': 'xtc',
  'str': 'gro',
  'cpt_out': 'false',
  'edr_out': 'false',
  'xvg_out': 'true',
  'tpr_out': 'true'},
 'sets': {'ensemble': 'nvt',
  'mdp': {'mdpfile': 'custom',
   'mdp_input': {'values': [{'id': 'ac6eff99a4eb515d',
      'src': 'hda'}]}}},
 'capture_log': 'true'}
```

With the current implementation, if a user wants to rerun a job run with the set of parameters above, but to make a single change, e.g. to update `tpr_out` to `false`, they need to submit `tool_inputs_update={'outps' {'traj': 'xtc', 'str': 'gro', 'cpt_out': 'false', 'edr_out': 'false', 'xvg_out': 'true', 'tpr_out': 'false'}}` which is not ideal.

With this PR, the `tool_inputs` will be recursively updated and `tool_inputs_update={'outps': {'tpr_out': 'false'}}` will be sufficient.