### PR TITLE
Add GET /api/tools/{tool_id}/reload

### DIFF
--- a/bioblend/_tests/TestGalaxyTools.py
+++ b/bioblend/_tests/TestGalaxyTools.py
@@ -142,6 +142,13 @@ class TestGalaxyTools(GalaxyTestBase.GalaxyTestBase):
             f"tool_requirements is {tool_requirements}",
         )
 
+    @test_util.skip_unless_tool('CONVERTER_fasta_to_bowtie_color_index')
+    def test_reload(self):
+        response = self.gi.tools.reload('CONVERTER_fasta_to_bowtie_color_index')
+        self.assertIsInstance(response, dict)
+        self.assertIn('message', response)
+        self.assertIn('id', response['message'])
+
     @test_util.skip_unless_tool('sra_source')
     def test_get_citations(self):
         citations = self.gi.tools.get_citations('sra_source')

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -105,6 +105,14 @@ class ToolClient(Client):
         url = self._make_url(tool_id) + '/requirements'
         return self._get(url=url)
 
+    def reload(self, tool_id):
+        """
+        Reload specified tool.
+        This functionality is available only to Galaxy admins.
+        """
+        url = self._make_url(tool_id) + '/reload'
+        return self._get(url=url)
+
     def get_citations(self, tool_id: str) -> List[dict]:
         """
         Get BibTeX citations for a given tool ID.

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -105,7 +105,7 @@ class ToolClient(Client):
         url = self._make_url(tool_id) + '/requirements'
         return self._get(url=url)
 
-    def reload(self, tool_id):
+    def reload(self, tool_id: str) -> dict:
         """
         Reload the specified tool in the toolbox. Any changes that have been made to the wrapper
         since the tool was last reloaded will take effect.

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -123,7 +123,7 @@ class ToolClient(Client):
                        'version': '3.4+galaxy1'}}
         """
         url = self._make_url(tool_id) + '/reload'
-        return self._get(url=url)
+        return self._put(url=url)
 
     def get_citations(self, tool_id: str) -> List[dict]:
         """

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -107,7 +107,8 @@ class ToolClient(Client):
 
     def reload(self, tool_id):
         """
-        Reload the specified tool in the toolbox.
+        Reload the specified tool in the toolbox. Any changes that have been made to the wrapper
+        since the tool was last reloaded will take effect.
         This functionality is available only to Galaxy admins.
 
         :type tool_id: str

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -107,8 +107,19 @@ class ToolClient(Client):
 
     def reload(self, tool_id):
         """
-        Reload specified tool.
+        Reload the specified tool in the toolbox.
         This functionality is available only to Galaxy admins.
+
+        :type tool_id: str
+        :param tool_id: id of the requested tool
+
+        :rtype: dict
+        :param: dict containing the id, name, and version of the reloaded tool.
+          For example:
+
+          {'message': {'name': 'Cutadapt',
+                       'id': 'toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/3.4+galaxy1',
+                       'version': '3.4+galaxy1'}}
         """
         url = self._make_url(tool_id) + '/reload'
         return self._get(url=url)

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -116,7 +116,7 @@ class ToolClient(Client):
 
         :rtype: dict
         :param: dict containing the id, name, and version of the reloaded tool.
-          For example:
+          For example::
 
           {'message': {'name': 'Cutadapt',
                        'id': 'toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/3.4+galaxy1',


### PR DESCRIPTION
Add `reload` function to bioblend.galaxy.tools.

This reloads a single tool and can be useful if a wrapper has been altered.  I can't think of a way to test this.

