### PR TITLE
Only use json.dump if payload is not None

### DIFF
--- a/bioblend/galaxy/client.py
+++ b/bioblend/galaxy/client.py
@@ -154,7 +154,7 @@ class Client:
                 bioblend.log.warning(msg)
                 time.sleep(retry_delay)
 
-    def _post(self, payload, id=None, deleted=False, contents=None, url=None,
+    def _post(self, payload=None, id=None, deleted=False, contents=None, url=None,
               files_attached=False):
         """
         Do a generic POST request, composing the url from the contents of the
@@ -176,7 +176,7 @@ class Client:
         return self.gi.make_post_request(url, payload=payload,
                                          files_attached=files_attached)
 
-    def _put(self, payload, id=None, url=None, params=None):
+    def _put(self, payload=None, id=None, url=None, params=None):
         """
         Do a generic PUT request, composing the url from the contents of the
         arguments. Alternatively, an explicit ``url`` can be provided to use
@@ -191,7 +191,7 @@ class Client:
             url = self._make_url(module_id=id)
         return self.gi.make_put_request(url, payload=payload, params=params)
 
-    def _patch(self, payload, id=None, url=None, params=None):
+    def _patch(self, payload=None, id=None, url=None, params=None):
         """
         Do a generic PATCH request, composing the url from the contents of the
         arguments. Alternatively, an explicit ``url`` can be provided to use

--- a/bioblend/galaxy/groups/__init__.py
+++ b/bioblend/galaxy/groups/__init__.py
@@ -155,7 +155,7 @@ class GroupsClient(Client):
         :return: Added group user's info
         """
         url = '/'.join((self._make_url(group_id), 'users', user_id))
-        return self._put(payload={}, url=url)
+        return self._put(url=url)
 
     def add_group_role(self, group_id, role_id):
         """
@@ -171,7 +171,7 @@ class GroupsClient(Client):
         :return: Added group role's info
         """
         url = '/'.join((self._make_url(group_id), 'roles', role_id))
-        return self._put(payload={}, url=url)
+        return self._put(url=url)
 
     def delete_group_user(self, group_id, user_id):
         """

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -562,7 +562,7 @@ class HistoryClient(Client):
         :return: 'OK' if it was deleted
         """
         url = self._make_url(history_id, deleted=True) + '/undelete'
-        return self._post(payload={}, url=url)
+        return self._post(url=url)
 
     def get_status(self, history_id):
         """
@@ -646,7 +646,7 @@ class HistoryClient(Client):
         time_left = maxwait
         while True:
             try:
-                r = self._put(payload={}, url=url, params=params)
+                r = self._put(url=url, params=params)
             except ConnectionError as e:
                 if e.status_code == 202:  # export is not ready
                     if time_left > 0:

--- a/bioblend/galaxy/jobs/__init__.py
+++ b/bioblend/galaxy/jobs/__init__.py
@@ -405,7 +405,7 @@ class JobsClient(Client):
           This method is only supported by Galaxy 18.09 or later.
         """
         url = self._make_url(module_id=job_id) + '/resume'
-        return self._put(url=url, payload={})
+        return self._put(url=url)
 
     def get_destination_params(self, job_id: str) -> dict:
         """

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -131,7 +131,7 @@ class ToolClient(Client):
         :return: Tool requirement status
         """
         url = self._make_url(tool_id) + '/install_dependencies'
-        return self._post(payload={}, url=url)
+        return self._post(url=url)
 
     def uninstall_dependencies(self, tool_id: str) -> dict:
         """
@@ -146,7 +146,7 @@ class ToolClient(Client):
         :return: Tool requirement status
         """
         url = self._make_url(tool_id) + '/dependencies'
-        return self._delete(payload={}, url=url)
+        return self._delete(url=url)
 
     def show_tool(self, tool_id, io_details=False, link_details=False):
         """

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -171,8 +171,6 @@ class GalaxyClient:
         :rtype: requests.Response
         :return: the response object.
         """
-        if payload is not None:
-            payload = json.dumps(payload)
         headers = self.json_headers
         r = requests.delete(
             url,
@@ -194,7 +192,6 @@ class GalaxyClient:
 
         :return: The decoded response.
         """
-        payload = json.dumps(payload)
         headers = self.json_headers
         r = requests.put(
             url,
@@ -230,7 +227,6 @@ class GalaxyClient:
 
         :return: The decoded response.
         """
-        payload = json.dumps(payload)
         headers = self.json_headers
         r = requests.patch(
             url,

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -171,6 +171,8 @@ class GalaxyClient:
         :rtype: requests.Response
         :return: the response object.
         """
+        if payload is not None:
+            payload = json.dumps(payload)
         headers = self.json_headers
         r = requests.delete(
             url,
@@ -192,6 +194,8 @@ class GalaxyClient:
 
         :return: The decoded response.
         """
+        if payload is not None:
+            payload = json.dumps(payload)
         headers = self.json_headers
         r = requests.put(
             url,
@@ -227,6 +231,8 @@ class GalaxyClient:
 
         :return: The decoded response.
         """
+        if payload is not None:
+            payload = json.dumps(payload)
         headers = self.json_headers
         r = requests.patch(
             url,

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -89,7 +89,7 @@ class GalaxyClient:
         r = requests.get(url, headers=headers, **kwargs)
         return r
 
-    def make_post_request(self, url, payload, params=None, files_attached=False):
+    def make_post_request(self, url, payload=None, params=None, files_attached=False):
         """
         Make a POST request using the provided ``url`` and ``payload``.
         The ``payload`` must be a dict that contains the request values.
@@ -126,7 +126,8 @@ class GalaxyClient:
             headers['Content-Type'] = payload.content_type
             post_params = None
         else:
-            payload = json.dumps(payload)
+            if payload is not None:
+                payload = json.dumps(payload)
             headers = self.json_headers
             post_params = params
 


### PR DESCRIPTION
Otherwise we send a request body that is `b"null"` (instead of `b""`), which is a problem for the Galaxy API. This means we could drop the `payload={}` we have in many places of the code.