### PR TITLE
`forms`: Type Annotations

### DIFF
--- a/bioblend/galaxy/forms/__init__.py
+++ b/bioblend/galaxy/forms/__init__.py
@@ -21,7 +21,7 @@ class FormsClient(Client):
     def __init__(self, galaxy_instance: "GalaxyInstance") -> None:
         super().__init__(galaxy_instance)
 
-    def get_forms(self) -> List[Dict[str, str]]:
+    def get_forms(self) -> List[Dict[str, Any]]:
         """
         Get the list of all forms.
 
@@ -40,7 +40,7 @@ class FormsClient(Client):
         """
         return self._get()
 
-    def show_form(self, form_id: str) -> Dict[str, Union[str, List[Any]]]:
+    def show_form(self, form_id: str) -> Dict[str, Any]:
         """
         Get details of a given form.
 

--- a/bioblend/galaxy/forms/__init__.py
+++ b/bioblend/galaxy/forms/__init__.py
@@ -1,16 +1,27 @@
 """
 Contains possible interactions with the Galaxy Forms
 """
+from typing import (
+    Any,
+    Dict,
+    List,
+    TYPE_CHECKING,
+    Union,
+)
+
 from bioblend.galaxy.client import Client
+
+if TYPE_CHECKING:
+    from bioblend.galaxy import GalaxyInstance
 
 
 class FormsClient(Client):
     module = "forms"
 
-    def __init__(self, galaxy_instance):
+    def __init__(self, galaxy_instance: "GalaxyInstance") -> None:
         super().__init__(galaxy_instance)
 
-    def get_forms(self):
+    def get_forms(self) -> List[Dict[str, str]]:
         """
         Get the list of all forms.
 
@@ -29,7 +40,7 @@ class FormsClient(Client):
         """
         return self._get()
 
-    def show_form(self, form_id):
+    def show_form(self, form_id: str) -> Dict[str, Union[str, List[Any]]]:
         """
         Get details of a given form.
 
@@ -51,15 +62,15 @@ class FormsClient(Client):
         """
         return self._get(id=form_id)
 
-    def create_form(self, form_xml_text):
+    def create_form(self, form_xml_text: str) -> str:
         """
         Create a new form.
 
-        :type   form_xml_text: str
-        :param  form_xml_text: Form xml to create a form on galaxy instance
+        :type form_xml_text: str
+        :param form_xml_text: Form xml to create a form on galaxy instance
 
-        :rtype:     str
-        :return:   Unique URL of newly created form with encoded id
+        :rtype: str
+        :return: Unique URL of newly created form with encoded id
         """
         payload = form_xml_text
         return self._post(payload=payload)

--- a/bioblend/galaxy/forms/__init__.py
+++ b/bioblend/galaxy/forms/__init__.py
@@ -6,7 +6,6 @@ from typing import (
     Dict,
     List,
     TYPE_CHECKING,
-    Union,
 )
 
 from bioblend.galaxy.client import Client


### PR DESCRIPTION
Type annotating `forms`.

Validated with: `tox -e lint`
Result: `lint: commands succeeded`