### PR TITLE
Remove unused methods from ``bioblend.config.Config``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   ``GalaxyInstance`` to ``GalaxyClient``, so they are also available in
   ``ToolshedInstance``.
 
+* Remove unused methods from ``bioblend.config.Config``. If needed, use the
+  methods inherited from `configparser.ConfigParser` instead.
+
 * Added Code of Conduct for the project.
 
 * Improvements to type annotations, tests and documentation.

--- a/bioblend/config.py
+++ b/bioblend/config.py
@@ -1,5 +1,6 @@
 import configparser
 import os
+from typing import TextIO
 
 BioBlendConfigPath = "/etc/bioblend.cfg"
 BioBlendConfigLocations = [BioBlendConfigPath]
@@ -17,48 +18,12 @@ class Config(configparser.ConfigParser):
     * Individual user: ``~/.bioblend`` (which works on both Windows and Unix)
     """
 
-    def __init__(self, path=None, fp=None, do_load=True):
+    def __init__(self, path: str = None, fp: TextIO = None, do_load: bool = True) -> None:
         super().__init__({"working_dir": "/mnt/pyami", "debug": "0"})
         if do_load:
             if path:
-                self.load_from_path(path)
+                self.read([path])
             elif fp:
-                self.readfp(fp)
+                self.read_file(fp)
             else:
                 self.read(BioBlendConfigLocations)
-
-    def get_value(self, section, name, default=None):
-        return self.get(section, name, default)
-
-    def get(self, section, name, default=None):
-        """ """
-        try:
-            val = super().get(section, name)
-        except Exception:
-            val = default
-        return val
-
-    def getint(self, section, name, default=0):
-        try:
-            val = super().getint(section, name)
-        except Exception:
-            val = int(default)
-        return val
-
-    def getfloat(self, section, name, default=0.0):
-        try:
-            val = super().getfloat(section, name)
-        except Exception:
-            val = float(default)
-        return val
-
-    def getbool(self, section, name, default=False):
-        if self.has_option(section, name):
-            val = self.get(section, name)
-            if val.lower() == "true":
-                val = True
-            else:
-                val = False
-        else:
-            val = default
-        return val


### PR DESCRIPTION
If needed, use the methods inherited from `configparser.ConfigParser` instead.

Also:
- Type annotations.