### PR TITLE
Add argument `require_exact_tool_versions` to `invoke_workflow`

### DIFF
--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -293,6 +293,7 @@ class WorkflowClient(Client):
         allow_tool_state_corrections: bool = False,
         inputs_by: Optional[str] = None,
         parameters_normalized: bool = False,
+        require_exact_tool_versions: bool = True,
     ) -> dict:
         """
         Invoke the workflow identified by ``workflow_id``. This will
@@ -485,7 +486,9 @@ class WorkflowClient(Client):
         if allow_tool_state_corrections:
             payload["allow_tool_state_corrections"] = allow_tool_state_corrections
         if inputs_by is not None:
-            payload["inputs_by"] = inputs_by
+            payload['inputs_by'] = inputs_by
+        if not require_exact_tool_versions:
+            payload['require_exact_tool_versions'] = require_exact_tool_versions
         if parameters_normalized:
             payload["parameters_normalized"] = parameters_normalized
         url = self._invocations_url(workflow_id)

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -492,8 +492,7 @@ class WorkflowClient(Client):
             payload["allow_tool_state_corrections"] = allow_tool_state_corrections
         if inputs_by is not None:
             payload["inputs_by"] = inputs_by
-        if not require_exact_tool_versions:
-            payload["require_exact_tool_versions"] = require_exact_tool_versions
+        payload["require_exact_tool_versions"] = require_exact_tool_versions
         if parameters_normalized:
             payload["parameters_normalized"] = parameters_normalized
         url = self._invocations_url(workflow_id)

--- a/bioblend/galaxy/workflows/__init__.py
+++ b/bioblend/galaxy/workflows/__init__.py
@@ -359,6 +359,11 @@ class WorkflowClient(Client):
           ``False``, but when setting ``params`` for a subworkflow, ``True`` is
           required.
 
+        :type require_exact_tool_versions: bool
+        :param require_exact_tool_versions: Whether invocation should fail if
+          Galaxy does not have the exact tool versions. Default is ``True``.
+          Parameter does not any effect for Galaxy versions < 22.05.
+
         :rtype: dict
         :return: A dict containing the workflow invocation describing the
           scheduling of the workflow. For example::
@@ -486,9 +491,9 @@ class WorkflowClient(Client):
         if allow_tool_state_corrections:
             payload["allow_tool_state_corrections"] = allow_tool_state_corrections
         if inputs_by is not None:
-            payload['inputs_by'] = inputs_by
+            payload["inputs_by"] = inputs_by
         if not require_exact_tool_versions:
-            payload['require_exact_tool_versions'] = require_exact_tool_versions
+            payload["require_exact_tool_versions"] = require_exact_tool_versions
         if parameters_normalized:
             payload["parameters_normalized"] = parameters_normalized
         url = self._invocations_url(workflow_id)


### PR DESCRIPTION
Add argument `require_exact_tool_versions` (new in 22.05) to invoke_workflow.  This is true by default but can be set to False in the params.