### PR TITLE
Add py.typed marker

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ graft bioblend/_tests
 graft docs
 
 global-exclude *.swp *.pyc .gitignore
+global-include bioblend/py.typed
 
 include *.rst CITATION LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ install_requires =
     typing-extensions
 packages = find:
 python_requires = >=3.7
+include_package_data = True
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
That's needed so type annotations are available in projects that use bioblend.