### PR TITLE
allow changing extra_user_preferences via update_user call.

### DIFF
--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -231,14 +231,16 @@ class UserClient(Client):
         url = self._make_url(user_id) + "/api_key"
         return self._get(url=url)
 
-    def update_user(self, user_id: str, update_data: dict = {}, **kwargs: Any) -> Dict[str, Any]:
+    def update_user(self, user_id: str, user_data: Optional[Dict] = None, **kwargs: Any) -> Dict[str, Any]:
         """
         Update user information. You can either pass a dict of all attributes you want to change, or provide them as kwargs.
         For attributes that cannot be expressed as a kwarg (extra_user_preferences use a | sign) pass them as update_data.
-        Some of the attributes that can be modified are documented below.
 
         :type user_id: str
         :param user_id: encoded user ID
+
+        :type user_data: dict
+        :param user_data: a dict containing the values to be updated, eg. { "username" : "newUsername", "email": "new@email" }
 
         :type username: str
         :param username: Replace user name with the given string
@@ -249,6 +251,8 @@ class UserClient(Client):
         :rtype: dict
         :return: details of the updated user
         """
-        update_data.update(kwargs)
+        if user_data is None:
+            user_data = {}
+        user_data.update(kwargs)
         url = self._make_url(user_id) + "/information/inputs"
-        return self._put(url=url, payload=update_data, id=user_id)
+        return self._put(url=url, payload=user_data, id=user_id)

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -233,8 +233,11 @@ class UserClient(Client):
 
     def update_user(self, user_id: str, user_data: Optional[Dict] = None, **kwargs: Any) -> Dict[str, Any]:
         """
-        Update user information. You can either pass a dict of all attributes you want to change, or provide them as kwargs.
-        For attributes that cannot be expressed as a kwarg (extra_user_preferences use a | sign) pass them as update_data.
+        Update user information. You can either pass the attributes you want to
+        change in the user_data dictionary, or provide them separately as
+        keyword arguments.
+        For attributes that cannot be expressed as keywords (e.g.
+        extra_user_preferences use a `|` sign), pass them in user_data.
 
         :type user_id: str
         :param user_id: encoded user ID

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -231,10 +231,11 @@ class UserClient(Client):
         url = self._make_url(user_id) + "/api_key"
         return self._get(url=url)
 
-    def update_user(self, user_id: str, **kwargs: Any) -> Dict[str, Any]:
+    def update_user(self, user_id: str, update_data: dict = {}, **kwargs: Any) -> Dict[str, Any]:
         """
-        Update user information. Some of the attributes that can be
-        modified are documented below.
+        Update user information. You can either pass a dict of all attributes you want to change, or provide them as kwargs.
+        For attributes that cannot be expressed as a kwarg (extra_user_preferences use a | sign) pass them as update_data.
+        Some of the attributes that can be modified are documented below.
 
         :type user_id: str
         :param user_id: encoded user ID
@@ -248,5 +249,6 @@ class UserClient(Client):
         :rtype: dict
         :return: details of the updated user
         """
+        update_data.update(kwargs)
         url = self._make_url(user_id) + "/information/inputs"
-        return self._put(url=url, payload=kwargs, id=user_id)
+        return self._put(url=url, payload=update_data, id=user_id)


### PR DESCRIPTION
I have an extra_user_preference configured, relevant section of user_preferences_extra_conf.yml of my galaxy config:
```yaml
preferences:
    bpadp:
      description: Bpa Data Portal API token
      inputs:
        - name: api_token
          label: Api Token
          type: text
          required: False
```

This translates into a preference key called "bpadp|api_token" which cannot be passed into UserClient.update_user as a kwarg ("|" is a forbidden character in python variables). I updated update_user to accept a dict as second positional parameter, allowing updating such preferences Ala:
`update_user("someID",{"bpadp|api_token":"value"})`

The change is backwards compatible and still supports kwargs passing. 