### PR TITLE
Allow to keep quota's default value

### DIFF
--- a/bioblend/_tests/TestGalaxyQuotas.py
+++ b/bioblend/_tests/TestGalaxyQuotas.py
@@ -44,6 +44,31 @@ class TestGalaxyQuotas(GalaxyTestBase.GalaxyTestBase):
         assert quota["operation"] == "-"
         assert quota["description"] == "asdf"
 
+    def test_update_quota_nondefault(self):
+        """
+        try to update a non-default quota (and leave it non-default)
+        """
+        # 1st make it non-default
+        response = self.gi.quotas.update_quota(
+            self.quota["id"],
+            name=self.quota_name,
+            description="testing",
+            default="no",
+            operation="=",
+            amount="100 GB",
+        )
+        assert f"has been renamed to '{self.quota_name}'" in response
+        assert f"Quota '{self.quota_name}' is no longer the default for registered users." in response
+
+        # update it leaving it non-default
+        response = self.gi.quotas.update_quota(
+            self.quota["id"],
+            name=self.quota_name + "-updated",
+        )
+        assert f"""Quota '{self.quota_name}' has been renamed to '{self.quota_name}-updated'""" in response
+        quota = self.gi.quotas.show_quota(self.quota["id"])
+        assert quota["default"] == "no"
+
     def test_delete_undelete_quota(self):
         self.gi.quotas.update_quota(self.quota["id"], default="no")
         response = self.gi.quotas.delete_quota(self.quota["id"])

--- a/bioblend/_tests/TestGalaxyQuotas.py
+++ b/bioblend/_tests/TestGalaxyQuotas.py
@@ -64,7 +64,8 @@ class TestGalaxyQuotas(GalaxyTestBase.GalaxyTestBase):
         response = self.gi.quotas.update_quota(
             self.quota["id"],
             name=self.quota_name + "-updated",
-        )
+            default = None, 
+        ) 
         assert f"""Quota '{self.quota_name}' has been renamed to '{self.quota_name}-updated'""" in response
         quota = self.gi.quotas.show_quota(self.quota["id"])
         assert quota["default"] == "no"

--- a/bioblend/_tests/TestGalaxyQuotas.py
+++ b/bioblend/_tests/TestGalaxyQuotas.py
@@ -64,7 +64,6 @@ class TestGalaxyQuotas(GalaxyTestBase.GalaxyTestBase):
         response = self.gi.quotas.update_quota(
             self.quota["id"],
             name=self.quota_name + "-updated",
-            default=None,
         )
         assert f"""Quota '{self.quota_name}' has been renamed to '{self.quota_name}-updated'""" in response
         quota = self.gi.quotas.show_quota(self.quota["id"])

--- a/bioblend/_tests/TestGalaxyQuotas.py
+++ b/bioblend/_tests/TestGalaxyQuotas.py
@@ -64,11 +64,11 @@ class TestGalaxyQuotas(GalaxyTestBase.GalaxyTestBase):
         response = self.gi.quotas.update_quota(
             self.quota["id"],
             name=self.quota_name + "-updated",
-            default = None, 
-        ) 
+            default=None,
+        )
         assert f"""Quota '{self.quota_name}' has been renamed to '{self.quota_name}-updated'""" in response
         quota = self.gi.quotas.show_quota(self.quota["id"])
-        assert quota["default"] == "no"
+        assert quota["default"] == []  # non-default quotas have []
 
     def test_delete_undelete_quota(self):
         self.gi.quotas.update_quota(self.quota["id"], default="no")

--- a/bioblend/galaxy/quotas/__init__.py
+++ b/bioblend/galaxy/quotas/__init__.py
@@ -142,7 +142,7 @@ class QuotaClient(Client):
         description: Optional[str] = None,
         amount: Optional[str] = None,
         operation: Optional[QuotaOperations] = None,
-        default: str = "no",
+        default: Optional[str] = None,
         in_users: Optional[List[str]] = None,
         in_groups: Optional[List[str]] = None,
     ) -> str:
@@ -172,7 +172,7 @@ class QuotaClient(Client):
                         are ``no``, ``unregistered``, ``registered``.
                         Calling this method with ``default="no"`` on a
                         non-default quota will throw an error. Not
-                        passing this parameter is equivalent to passing ``no``.
+                        passing this parameter will leave the default state as it is.
 
         :type in_users: list of str
         :param in_users: A list of user IDs or user emails.
@@ -186,7 +186,11 @@ class QuotaClient(Client):
 
             "Quota 'Testing-A' has been renamed to 'Testing-B'; Quota 'Testing-e' is now '-100.0 GB'; Quota 'Testing-B' is now the default for unregistered users"
         """
-        payload: Dict[str, Any] = {"default": default}
+        payload: Dict[str, Any] = {}
+
+        if default:
+            payload["default"] = default
+
         if name:
             payload["name"] = name
 

--- a/bioblend/galaxy/quotas/__init__.py
+++ b/bioblend/galaxy/quotas/__init__.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from bioblend.galaxy import GalaxyInstance
 
 QuotaOperations = Literal["+", "-", "="]
+QuotaDefault = Literal["no", "registered", "unregistered"]
 
 
 class QuotaClient(Client):
@@ -80,7 +81,7 @@ class QuotaClient(Client):
         description: str,
         amount: str,
         operation: QuotaOperations,
-        default: Optional[Literal["no", "registered", "unregistered"]] = "no",
+        default: Optional[QuotaDefault] = "no",
         in_users: Optional[List[str]] = None,
         in_groups: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
@@ -142,7 +143,7 @@ class QuotaClient(Client):
         description: Optional[str] = None,
         amount: Optional[str] = None,
         operation: Optional[QuotaOperations] = None,
-        default: Optional[str] = None,
+        default: Optional[QuotaDefault] = "no",
         in_users: Optional[List[str]] = None,
         in_groups: Optional[List[str]] = None,
     ) -> str:
@@ -171,8 +172,8 @@ class QuotaClient(Client):
         :param default: Whether or not this is a default quota. Valid values
                         are ``no``, ``unregistered``, ``registered``.
                         Calling this method with ``default="no"`` on a
-                        non-default quota will throw an error. Not
-                        passing this parameter will leave the default state as it is.
+                        non-default quota will throw an error. None
+                        will leave the default state as it is.
 
         :type in_users: list of str
         :param in_users: A list of user IDs or user emails.

--- a/bioblend/galaxy/quotas/__init__.py
+++ b/bioblend/galaxy/quotas/__init__.py
@@ -143,7 +143,7 @@ class QuotaClient(Client):
         description: Optional[str] = None,
         amount: Optional[str] = None,
         operation: Optional[QuotaOperations] = None,
-        default: Optional[QuotaDefault] = "no",
+        default: Optional[QuotaDefault] = None,
         in_users: Optional[List[str]] = None,
         in_groups: Optional[List[str]] = None,
     ) -> str:


### PR DESCRIPTION
in the current implementation, it was impossible to update a quota and to leave the `default = "no"`.

was documented correctly but likely undesired .. for instance, it seemed impossible to just change the value of an existing non-default quota.

Edit: you can see it failing over here https://github.com/galaxyproject/bioblend/pull/479. I cherry-picked the test to this PR

TODO: change the default of the default parameter?