### PR TITLE
Time filters for histories.get_histories

### DIFF
--- a/bioblend/_tests/TestGalaxyHistories.py
+++ b/bioblend/_tests/TestGalaxyHistories.py
@@ -73,6 +73,17 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
         histories = self.gi.histories.get_histories(name=self.default_history_name)
         assert len([h for h in histories if h["id"] == self.history["id"]]) == 1
 
+        # Test for time filters. We expect all histories to have been created an updated within the last few minutes
+        new_histories = self.gi.histories.get_histories(
+            create_time_min="2023-07-04T11:00:01", update_time_min="2023-08-06T11:00:05"
+        )
+        assert len(new_histories) == len(all_histories)
+
+        old_histories = self.gi.histories.get_histories(
+            create_time_max="2023-07-04T11:00:01", update_time_max="2023-08-06T11:00:05"
+        )
+        assert len(old_histories) == 0
+
         # TODO: check whether deleted history is returned correctly
         # At the moment, get_histories() returns only not-deleted histories
         # and get_histories(deleted=True) returns only deleted histories,

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -88,6 +88,10 @@ class HistoryClient(Client):
         filter_user_published: Optional[bool] = None,
         get_all_published: bool = False,
         slug: Optional[str] = None,
+        create_time_min: Optional[str] = None,
+        create_time_max: Optional[str] = None,
+        update_time_min: Optional[str] = None,
+        update_time_max: Optional[str] = None,
         all: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         """
@@ -105,6 +109,18 @@ class HistoryClient(Client):
         if slug is not None:
             params.setdefault("q", []).append("slug")
             params.setdefault("qv", []).append(slug)
+        if create_time_min:
+            params.setdefault("q", []).append("create_time-ge")
+            params.setdefault("qv", []).append(create_time_min)
+        if create_time_max:
+            params.setdefault("q", []).append("create_time-le")
+            params.setdefault("qv", []).append(create_time_max)
+        if update_time_min:
+            params.setdefault("q", []).append("update_time-ge")
+            params.setdefault("qv", []).append(update_time_min)
+        if update_time_max:
+            params.setdefault("q", []).append("update_time-le")
+            params.setdefault("qv", []).append(update_time_max)
         if all:
             params["all"] = True
 
@@ -122,6 +138,10 @@ class HistoryClient(Client):
         deleted: bool = False,
         published: Optional[bool] = None,
         slug: Optional[str] = None,
+        create_time_min: Optional[str] = None,
+        create_time_max: Optional[str] = None,
+        update_time_min: Optional[str] = None,
+        update_time_max: Optional[str] = None,
         all: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         """
@@ -145,6 +165,22 @@ class HistoryClient(Client):
         :type slug: str
         :param slug: History slug to filter on
 
+        :type create_time_min: str
+        :param create_time_min: Return histories created after the provided
+          time and date, which should be formatted as ``YYYY-MM-DDTHH-MM-SS``.
+
+        :type create_time_max: str
+        :param create_time_max: Return histories created before the provided
+          time and date, which should be formatted as ``YYYY-MM-DDTHH-MM-SS``.
+
+        :type update_time_min: str
+        :param update_time_min: Return histories last updated after the provided
+          time and date, which should be formatted as ``YYYY-MM-DDTHH-MM-SS``.
+
+        :type update_time_max: str
+        :param update_time_max: Return histories last updated before the provided
+          time and date, which should be formatted as ``YYYY-MM-DDTHH-MM-SS``.
+
         :type all: bool
         :param all: Whether to include histories from other users. This
           parameter works only on Galaxy 20.01 or later and can be specified
@@ -162,11 +198,27 @@ class HistoryClient(Client):
                 "The history_id parameter has been removed, use the show_history() method to view details of a history for which you know the ID.",
             )
         return self._get_histories(
-            name=name, deleted=deleted, filter_user_published=published, get_all_published=False, slug=slug, all=all
+            name=name,
+            deleted=deleted,
+            filter_user_published=published,
+            get_all_published=False,
+            slug=slug,
+            all=all,
+            create_time_min=create_time_min,
+            create_time_max=create_time_max,
+            update_time_min=update_time_min,
+            update_time_max=update_time_max,
         )
 
     def get_published_histories(
-        self, name: Optional[str] = None, deleted: bool = False, slug: Optional[str] = None
+        self,
+        name: Optional[str] = None,
+        deleted: bool = False,
+        slug: Optional[str] = None,
+        create_time_min: Optional[str] = None,
+        create_time_max: Optional[str] = None,
+        update_time_min: Optional[str] = None,
+        update_time_max: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Get all published histories (by any user), or select a subset by
@@ -182,11 +234,35 @@ class HistoryClient(Client):
         :type slug: str
         :param slug: History slug to filter on
 
+        :type create_time_min: str
+        :param create_time_min: Return histories created after the provided
+          time and date, which should be formatted as ``YYYY-MM-DDTHH-MM-SS``.
+
+        :type create_time_max: str
+        :param create_time_max: Return histories created before the provided
+          time and date, which should be formatted as ``YYYY-MM-DDTHH-MM-SS``.
+
+        :type update_time_min: str
+        :param update_time_min: Return histories last updated after the provided
+          time and date, which should be formatted as ``YYYY-MM-DDTHH-MM-SS``.
+
+        :type update_time_max: str
+        :param update_time_max: Return histories last updated before the provided
+          time and date, which should be formatted as ``YYYY-MM-DDTHH-MM-SS``.
+
         :rtype: list
         :return: List of history dicts.
         """
         return self._get_histories(
-            name=name, deleted=deleted, filter_user_published=None, get_all_published=True, slug=slug
+            name=name,
+            deleted=deleted,
+            filter_user_published=None,
+            get_all_published=True,
+            slug=slug,
+            create_time_min=create_time_min,
+            create_time_max=create_time_max,
+            update_time_min=update_time_min,
+            update_time_max=update_time_max,
         )
 
     @overload


### PR DESCRIPTION
Add filtering for `create_time-ge`, `create_time-le`,  `update_time-ge`, `update_time-le` for histories using the same keywords as used in `get_datasets` filtering. A lot of this is reused from `datasets/__init__.py` .