### PR TITLE
Add view, keys, limit and offset to get_histories

### DIFF
--- a/bioblend/_tests/TestGalaxyHistories.py
+++ b/bioblend/_tests/TestGalaxyHistories.py
@@ -89,9 +89,9 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
         histories_detailed = self.gi.histories.get_histories(view="detailed")
         assert "size" in histories_detailed[0]
 
-        # Test keys
+        # Test keys: check that fields requested are returned
         histories_with_keys = self.gi.histories.get_histories(keys=["id", "user_id", "size"])
-        assert set([key for key in histories_with_keys[0]]) == set(["id", "user_id", "size"])
+        assert {key for key in histories_with_keys[0]} >= {"id", "user_id", "size"}
 
         # TODO: check whether deleted history is returned correctly
         # At the moment, get_histories() returns only not-deleted histories

--- a/bioblend/_tests/TestGalaxyHistories.py
+++ b/bioblend/_tests/TestGalaxyHistories.py
@@ -85,6 +85,14 @@ class TestGalaxyHistories(GalaxyTestBase.GalaxyTestBase):
         )
         assert len(old_histories) == 0
 
+        # Test detailed view: check for presence of "size" field
+        histories_detailed = self.gi.histories.get_histories(view="detailed")
+        assert "size" in histories_detailed[0]
+
+        # Test keys
+        histories_with_keys = self.gi.histories.get_histories(keys=["id", "user_id", "size"])
+        assert set([key for key in histories_with_keys[0]]) == set(["id", "user_id", "size"])
+
         # TODO: check whether deleted history is returned correctly
         # At the moment, get_histories() returns only not-deleted histories
         # and get_histories(deleted=True) returns only deleted histories,

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -93,7 +93,7 @@ class HistoryClient(Client):
         create_time_max: Optional[str] = None,
         update_time_min: Optional[str] = None,
         update_time_max: Optional[str] = None,
-        view: Optional[str] = "summary",
+        view: Optional[str] = None,
         keys: Optional[List[str]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
@@ -155,7 +155,7 @@ class HistoryClient(Client):
         create_time_max: Optional[str] = None,
         update_time_min: Optional[str] = None,
         update_time_max: Optional[str] = None,
-        view: Optional[str] = 'summary',
+        view: Optional[str] = None,
         keys: Optional[List[str]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
@@ -205,7 +205,7 @@ class HistoryClient(Client):
 
         :type view: str
         :param view: Options are 'summary' or 'detailed'. This defaults to 'summary'.
-          Setting view to 'detailed' results in a larger number of fields returned. 
+          Setting view to 'detailed' results in a larger number of fields returned.
 
         :type keys: List[str]
         :param keys: List of fields to return
@@ -316,6 +316,7 @@ class HistoryClient(Client):
         visible: Optional[bool] = None,
         details: Optional[str] = None,
         types: Optional[List[str]] = None,
+        keys: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]: ...
 
     # Fallback in case the caller provides a regular bool as contents
@@ -328,6 +329,7 @@ class HistoryClient(Client):
         visible: Optional[bool] = None,
         details: Optional[str] = None,
         types: Optional[List[str]] = None,
+        keys: Optional[List[str]] = None,
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         pass
 
@@ -339,6 +341,7 @@ class HistoryClient(Client):
         visible: Optional[bool] = None,
         details: Optional[str] = None,
         types: Optional[List[str]] = None,
+        keys: Optional[List[str]] = None,
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """
         Get details of a given history. By default, just get the history meta
@@ -374,6 +377,9 @@ class HistoryClient(Client):
           ``['dataset_collection']``,  return only dataset collections. If not
           set, no filtering is applied.
 
+        :type keys: List[str]
+        :param keys: List of fields to return
+
         :rtype: dict or list of dicts
         :return: details of the given history or list of dataset info
 
@@ -393,6 +399,8 @@ class HistoryClient(Client):
                 params["visible"] = visible
             if types is not None:
                 params["types"] = types
+        if keys:
+            params["keys"] = ",".join(keys)
         return self._get(id=history_id, contents=contents, params=params)
 
     def delete_dataset(self, history_id: str, dataset_id: str, purge: bool = False) -> None:

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -93,6 +93,7 @@ class HistoryClient(Client):
         create_time_max: Optional[str] = None,
         update_time_min: Optional[str] = None,
         update_time_max: Optional[str] = None,
+        all: Optional[bool] = False,
         view: Optional[Literal["summary", "detailed"]] = None,
         keys: Optional[List[str]] = None,
         limit: Optional[int] = None,

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -160,7 +160,6 @@ class HistoryClient(Client):
         keys: Optional[List[str]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        all: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         """
         Get all histories, or select a subset by specifying optional arguments

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -155,7 +155,7 @@ class HistoryClient(Client):
         create_time_max: Optional[str] = None,
         update_time_min: Optional[str] = None,
         update_time_max: Optional[str] = None,
-        view: Optional[str] = None,
+        view: Optional[Literal["summary", "detailed"]] = None,
         keys: Optional[List[str]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -97,7 +97,6 @@ class HistoryClient(Client):
         keys: Optional[List[str]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        all: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         """
         Hidden method to be used by both get_histories() and get_published_histories()

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -155,6 +155,7 @@ class HistoryClient(Client):
         create_time_max: Optional[str] = None,
         update_time_min: Optional[str] = None,
         update_time_max: Optional[str] = None,
+        all: Optional[bool] = False,
         view: Optional[Literal["summary", "detailed"]] = None,
         keys: Optional[List[str]] = None,
         limit: Optional[int] = None,

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -93,6 +93,10 @@ class HistoryClient(Client):
         create_time_max: Optional[str] = None,
         update_time_min: Optional[str] = None,
         update_time_max: Optional[str] = None,
+        view: Optional[str] = "summary",
+        keys: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
         all: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         """
@@ -124,6 +128,14 @@ class HistoryClient(Client):
             params.setdefault("qv", []).append(update_time_max)
         if all:
             params["all"] = True
+        if view:
+            params["view"] = view
+        if keys:
+            params["keys"] = ",".join(keys)
+        if limit:
+            params["limit"] = limit
+        if offset:
+            params["offset"] = offset
 
         url = "/".join((self._make_url(), "published")) if get_all_published else None
         histories = self._get(url=url, params=params)
@@ -143,6 +155,10 @@ class HistoryClient(Client):
         create_time_max: Optional[str] = None,
         update_time_min: Optional[str] = None,
         update_time_max: Optional[str] = None,
+        view: Optional[str] = 'summary',
+        keys: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
         all: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         """
@@ -187,6 +203,20 @@ class HistoryClient(Client):
           parameter works only on Galaxy 20.01 or later and can be specified
           only if the user is a Galaxy admin.
 
+        :type view: str
+        :param view: Options are 'summary' or 'detailed'. This defaults to 'summary'.
+          Setting view to 'detailed' results in a larger number of fields returned. 
+
+        :type keys: List[str]
+        :param keys: List of fields to return
+
+        :type limit: int
+        :param limit: How many items to return (upper bound).
+
+        :type offset: int
+        :param offset: skip the first ( offset - 1 ) items and begin returning
+          at the Nth item.
+
         :rtype: list
         :return: List of history dicts.
 
@@ -205,6 +235,10 @@ class HistoryClient(Client):
             get_all_published=False,
             slug=slug,
             all=all,
+            view=view,
+            keys=keys,
+            limit=limit,
+            offset=offset,
             create_time_min=create_time_min,
             create_time_max=create_time_max,
             update_time_min=update_time_min,

--- a/bioblend/galaxy/histories/__init__.py
+++ b/bioblend/galaxy/histories/__init__.py
@@ -93,7 +93,7 @@ class HistoryClient(Client):
         create_time_max: Optional[str] = None,
         update_time_min: Optional[str] = None,
         update_time_max: Optional[str] = None,
-        view: Optional[str] = None,
+        view: Optional[Literal["summary", "detailed"]] = None,
         keys: Optional[List[str]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,


### PR DESCRIPTION
Adding `keys`, `limit` and `offset` are necessary for updating Galaxy Australia's history management script to use bioblend. 