### PR TITLE
Add ``quota_source_label`` parameter to ``QuotaClient.create_quota()``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added ``offset`` parameter to ``InvocationClient.get_invocations()`` and
   BioBlend.objects ``ObjInvocationClient.list()`` methods.
 
+* Added ``quota_source_label`` parameter to ``QuotaClient.create_quota()``
+  (thanks to [Matthias Bernt](https://github.com/bernt-matthias)).
+
 * Added ``style`` parameter to ``WorkflowClient.export_workflow_dict()`` method
   (thanks to [Marius van den Beek](https://github.com/mvdbeek)).
 

--- a/bioblend/galaxy/quotas/__init__.py
+++ b/bioblend/galaxy/quotas/__init__.py
@@ -82,6 +82,7 @@ class QuotaClient(Client):
         default: Optional[DefaultQuotaValues] = "no",
         in_users: Optional[list[str]] = None,
         in_groups: Optional[list[str]] = None,
+        quota_source_label: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Create a new quota
@@ -109,6 +110,10 @@ class QuotaClient(Client):
         :type in_groups: list of str
         :param in_groups: A list of group IDs or names.
 
+        :type quota_source_label: str
+        :param quota_source_label: If set, quota source label to apply this
+          quota operation to. Otherwise, the default quota is used.
+
         :rtype: dict
         :return: A description of quota.
           For example::
@@ -125,6 +130,7 @@ class QuotaClient(Client):
             "amount": amount,
             "operation": operation,
             "default": default,
+            "quota_source_label": quota_source_label,
         }
         if in_users:
             payload["in_users"] = in_users


### PR DESCRIPTION
Currently untested, since the test instance would need an object store setup. If easy to setup I could do it (usually testing is a good idea :) )