### PR TITLE
New functions support uploading and exporting invocations archives

### DIFF
--- a/bioblend/_tests/TestGalaxyInvocations.py
+++ b/bioblend/_tests/TestGalaxyInvocations.py
@@ -95,6 +95,7 @@ class TestGalaxyInvocations(GalaxyTestBase.GalaxyTestBase):
             ret = self.gi.invocations.get_invocation_report_pdf(invocation_id, "report.pdf")
             assert ret is None
 
+    @test_util.skip_unless_galaxy("release_23.0")
     def test_get_invocation_archive(self):
         invocation = self._invoke_workflow()
         payload = {

--- a/bioblend/galaxy/client.py
+++ b/bioblend/galaxy/client.py
@@ -92,6 +92,7 @@ class Client:
         params: Optional[dict] = None,
         *,
         json: Literal[False],
+        stream: Literal[False],
     ) -> requests.Response: ...
 
     @overload
@@ -103,6 +104,7 @@ class Client:
         url: Optional[str] = None,
         params: Optional[dict] = None,
         json: bool = True,
+        stream: bool = False,
     ) -> Any: ...
 
     def _get(
@@ -113,7 +115,7 @@ class Client:
         url: Optional[str] = None,
         params: Optional[dict] = None,
         json: bool = True,
-        **kwargs: Any,
+        stream: bool = False,
     ) -> Any:
         """
         Do a GET request, composing the URL from ``id``, ``deleted`` and
@@ -137,7 +139,7 @@ class Client:
         while attempts_left > 0:
             attempts_left -= 1
             try:
-                r = self.gi.make_get_request(url, params=params, **kwargs)
+                r = self.gi.make_get_request(url, params=params, stream=stream)
             except requests.exceptions.ConnectionError as e:
                 msg = str(e)
                 r = requests.Response()  # empty Response object used when raising ConnectionError

--- a/bioblend/galaxy/client.py
+++ b/bioblend/galaxy/client.py
@@ -113,6 +113,7 @@ class Client:
         url: Optional[str] = None,
         params: Optional[dict] = None,
         json: bool = True,
+        **kwargs: Any,
     ) -> Any:
         """
         Do a GET request, composing the URL from ``id``, ``deleted`` and
@@ -136,7 +137,7 @@ class Client:
         while attempts_left > 0:
             attempts_left -= 1
             try:
-                r = self.gi.make_get_request(url, params=params)
+                r = self.gi.make_get_request(url, params=params, **kwargs)
             except requests.exceptions.ConnectionError as e:
                 msg = str(e)
                 r = requests.Response()  # empty Response object used when raising ConnectionError

--- a/bioblend/galaxy/invocations/__init__.py
+++ b/bioblend/galaxy/invocations/__init__.py
@@ -289,18 +289,15 @@ class InvocationClient(Client):
         :param url: URL for an exported history archive
 
         """
+        payload: dict[str, Any] = {
+            "history_id": history_id,
+            "model_store_format": model_store_format,
+        }
         if file_path:
-            payload: dict[str, Any] = {
-                "history_id": history_id,
-                "model_store_format": model_store_format,
-                "store_content_uri": "base64://" + base64.b64encode(open(file_path, "rb").read()).decode("utf-8"),
-            }
+            with open(file_path, "rb") as reader:
+                payload["store_content_uri"] = "base64://" + base64.b64encode(reader.read()).decode("utf-8")
         else:
-            payload = {
-                "history_id": history_id,
-                "model_store_format": model_store_format,
-                "store_content_uri": url,
-            }
+            payload["store_content_uri"] = url
         url = "/".join((self._make_url(), "from_store"))
         return self._post(url=url, payload=payload)
 
@@ -462,8 +459,8 @@ class InvocationClient(Client):
         :type interval: float
         :param interval: Time (in seconds) to wait between 2 consecutive checks.
 
-        :rtype: requests.Response
-        :return:  Response containing storage object.
+        :return: The decoded response if ``json`` is set to ``True``, otherwise
+          the response object
         """
         url = f"{self.gi.url}/short_term_storage/{storage_request_id}"
         is_ready_url = f"{url}/ready"
@@ -492,8 +489,8 @@ class InvocationClient(Client):
           object to become ready. After this time, a ``TimeoutException`` will
           be raised.
 
-        :rtype: dict
-        :return: a request.Response
+        :rtype: requests.Response
+        :return: request.Response
         """
         url = self._make_url(invocation_id) + "/prepare_store_download"
         psd = self._post(url=url, payload=payload)


### PR DESCRIPTION
A new function has been added to support uploading archived invocations to Galaxy. The get_invocation_biocompute_object function now accepts a payload parameter, allowing the export format of the archive to be specified. Additionally, _wait_for_short_term_storage in invocations/__init__.py has been updated to stream data back.
