### PR TITLE
Add credential handling to UserClient and ToolClient

### DIFF
--- a/bioblend/_tests/TestGalaxyUsers.py
+++ b/bioblend/_tests/TestGalaxyUsers.py
@@ -197,7 +197,7 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
     def test_get_credentials_for_tool(self):
         user_id = self.gi.users.get_current_user()["id"]
         tool_id = f"test_credential_tool_run_{test_util.random_string()}"
-        self.gi.users.create_credentials(
+        group = self.gi.users.create_credentials(
             user_id=user_id,
             source_type="tool",
             source_id=tool_id,
@@ -206,6 +206,16 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
             service_version="2.0",
             group_name="default",
             secrets=[{"name": "token", "value": "abc123"}],
+        )
+        # Set the active credential group (not auto-set on creation)
+        creds = self.gi.users.get_credentials(user_id, source_id=tool_id)
+        self.gi.users.select_credential_group(
+            user_id=user_id,
+            source_type="tool",
+            source_id=tool_id,
+            source_version="1.0",
+            user_credentials_id=creds[0]["id"],
+            group_id=group["id"],
         )
         context = self.gi.users.get_credentials_for_tool(user_id, tool_id)
         assert context is not None
@@ -216,3 +226,9 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         assert entry["version"] == "2.0"
         assert "id" in entry["selected_group"]
         assert entry["selected_group"]["name"] == "default"
+
+    @test_util.skip_unless_galaxy("release_25.0")
+    def test_get_credentials_for_tool_none(self):
+        user_id = self.gi.users.get_current_user()["id"]
+        context = self.gi.users.get_credentials_for_tool(user_id, "nonexistent_tool_id")
+        assert context is None

--- a/bioblend/_tests/TestGalaxyUsers.py
+++ b/bioblend/_tests/TestGalaxyUsers.py
@@ -170,7 +170,7 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         tool_id = "secret_tool"
         tool = self.gi.tools.show_tool(tool_id)
         group_name = test_util.random_string()
-        cred = self.gi.users.create_credentials(
+        group = self.gi.users.create_credentials(
             user_id=user_id,
             source_type="tool",
             source_id=tool_id,
@@ -181,7 +181,7 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
             variables=[{"name": "server", "value": "https://example.org"}],
             secrets=[{"name": "username", "value": "alice"}, {"name": "password", "value": "s3cret"}],
         )
-        assert cred["name"] == group_name
+        assert group["name"] == group_name
         creds = self.gi.users.get_credentials(user_id, source_id=tool_id)
         matching = [c for c in creds if c["name"] == "service1"]
         assert len(matching) == 1

--- a/bioblend/_tests/TestGalaxyUsers.py
+++ b/bioblend/_tests/TestGalaxyUsers.py
@@ -89,9 +89,7 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         new_user_id = new_user["id"]
         updated_username = test_util.random_string()
         updated_user_email = f"{updated_username}@example.org"
-        self.gi.users.update_user(
-            new_user_id, username=updated_username, email=updated_user_email
-        )
+        self.gi.users.update_user(new_user_id, username=updated_username, email=updated_user_email)
         updated_user = self.gi.users.show_user(new_user_id)
         assert updated_user["username"] == updated_username
         assert updated_user["email"] == updated_user_email
@@ -112,9 +110,7 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         if self.gi.config.get_config()["use_remote_user"]:
             self.skipTest("This Galaxy instance is not configured to use local users")
         if not self.gi.config.get_config()["allow_user_deletion"]:
-            self.skipTest(
-                "This Galaxy instance is not configured to allow user deletion"
-            )
+            self.skipTest("This Galaxy instance is not configured to allow user deletion")
         new_username = test_util.random_string()
         new_user = self.gi.users.create_local_user(
             new_username, f"{new_username}@example.org", test_util.random_string(20)
@@ -159,75 +155,89 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         assert new_apikey and new_apikey != "Not available."
         # Test regenerating an API key for a user that already has one
         regenerated_apikey = self.gi.users.create_user_apikey(new_user_id)
-        assert regenerated_apikey and regenerated_apikey not in (
-            new_apikey,
-            "Not available.",
-        )
+        assert regenerated_apikey and regenerated_apikey not in (new_apikey, "Not available.")
 
-    @test_util.skip_unless_galaxy("release_25.0")
+    @test_util.skip_unless_galaxy("release_25.1")
     def test_get_credentials_empty(self):
         user_id = self.gi.users.get_current_user()["id"]
         creds = self.gi.users.get_credentials(user_id, source_id="nonexistent_tool_id")
         assert creds == []
 
-    @test_util.skip_unless_galaxy("release_25.0")
+    @test_util.skip_unless_galaxy("release_25.1")
     def test_create_and_get_credentials(self):
+        # Requires a Galaxy tool with credential definitions; skip if unavailable
         user_id = self.gi.users.get_current_user()["id"]
-        tool_id = f"test_credential_tool_{test_util.random_string()}"
-        cred = self.gi.users.create_credentials(
-            user_id=user_id,
-            source_type="tool",
-            source_id=tool_id,
-            source_version="1.0",
-            service_name="test_service",
-            service_version="1.0",
-            group_name="default",
-            variables=[{"name": "api_url", "value": "https://example.org"}],
-            secrets=[{"name": "api_key", "value": "secret123"}],
-        )
+        tool_id = "random_lines1"
+        tool = self.gi.tools.show_tool(tool_id)
+        try:
+            cred = self.gi.users.create_credentials(
+                user_id=user_id,
+                source_type="tool",
+                source_id=tool_id,
+                source_version=tool["version"],
+                service_name="test_service",
+                service_version="1.0",
+                group_name="default",
+                variables=[{"name": "api_url", "value": "https://example.org"}],
+                secrets=[{"name": "api_key", "value": "secret123"}],
+            )
+        except ConnectionError as e:
+            if "does not require any credentials" in str(e) or "not defined" in str(e):
+                self.skipTest("Test tool does not have credential definitions")
+            raise
         assert cred is not None
         creds = self.gi.users.get_credentials(user_id, source_id=tool_id)
-        assert len(creds) == 1
-        assert creds[0]["source_id"] == tool_id
-        assert creds[0]["name"] == "test_service"
-        assert creds[0]["version"] == "1.0"
-        assert len(creds[0]["groups"]) == 1
+        assert len(creds) >= 1
+        matching = [c for c in creds if c["name"] == "test_service"]
+        assert len(matching) == 1
+        assert matching[0]["source_id"] == tool_id
+        assert matching[0]["version"] == "1.0"
+        assert len(matching[0]["groups"]) >= 1
 
-    @test_util.skip_unless_galaxy("release_25.0")
+    @test_util.skip_unless_galaxy("release_25.1")
     def test_get_credentials_for_tool(self):
+        # Requires a Galaxy tool with credential definitions; skip if unavailable
         user_id = self.gi.users.get_current_user()["id"]
-        tool_id = f"test_credential_tool_run_{test_util.random_string()}"
-        group = self.gi.users.create_credentials(
-            user_id=user_id,
-            source_type="tool",
-            source_id=tool_id,
-            source_version="1.0",
-            service_name="test_service",
-            service_version="2.0",
-            group_name="default",
-            secrets=[{"name": "token", "value": "abc123"}],
-        )
+        tool_id = "random_lines1"
+        tool = self.gi.tools.show_tool(tool_id)
+        try:
+            group = self.gi.users.create_credentials(
+                user_id=user_id,
+                source_type="tool",
+                source_id=tool_id,
+                source_version=tool["version"],
+                service_name="test_service_run",
+                service_version="2.0",
+                group_name="default",
+                secrets=[{"name": "token", "value": "abc123"}],
+            )
+        except ConnectionError as e:
+            if "does not require any credentials" in str(e) or "not defined" in str(e):
+                self.skipTest("Test tool does not have credential definitions")
+            raise
         # Set the active credential group (not auto-set on creation)
         creds = self.gi.users.get_credentials(user_id, source_id=tool_id)
+        matching = [c for c in creds if c["name"] == "test_service_run"]
         self.gi.users.select_credential_group(
             user_id=user_id,
             source_type="tool",
             source_id=tool_id,
-            source_version="1.0",
-            user_credentials_id=creds[0]["id"],
+            source_version=tool["version"],
+            user_credentials_id=matching[0]["id"],
             group_id=group["id"],
         )
-        context = self.gi.users.get_credentials_for_tool(user_id, tool_id)
+        context = self.gi.users.get_credentials_for_tool(user_id, tool_id, tool_version=tool["version"])
         assert context is not None
-        assert len(context) == 1
-        entry = context[0]
+        assert len(context) >= 1
+        entries = [e for e in context if e["name"] == "test_service_run"]
+        assert len(entries) == 1
+        entry = entries[0]
         assert "user_credentials_id" in entry
-        assert entry["name"] == "test_service"
         assert entry["version"] == "2.0"
         assert "id" in entry["selected_group"]
         assert entry["selected_group"]["name"] == "default"
 
-    @test_util.skip_unless_galaxy("release_25.0")
+    @test_util.skip_unless_galaxy("release_25.1")
     def test_get_credentials_for_tool_none(self):
         user_id = self.gi.users.get_current_user()["id"]
         context = self.gi.users.get_credentials_for_tool(user_id, "nonexistent_tool_id")

--- a/bioblend/_tests/TestGalaxyUsers.py
+++ b/bioblend/_tests/TestGalaxyUsers.py
@@ -164,60 +164,52 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         assert creds == []
 
     @test_util.skip_unless_galaxy("release_25.1")
-    @test_util.skip_unless_tool("random_lines1")
+    @test_util.skip_unless_tool("secret_tool")
     def test_create_and_get_credentials(self):
         user_id = self.gi.users.get_current_user()["id"]
-        tool_id = "random_lines1"
+        tool_id = "secret_tool"
         tool = self.gi.tools.show_tool(tool_id)
-        try:
-            cred = self.gi.users.create_credentials(
-                user_id=user_id,
-                source_type="tool",
-                source_id=tool_id,
-                source_version=tool["version"],
-                service_name="test_service",
-                service_version="1.0",
-                group_name="default",
-                variables=[{"name": "api_url", "value": "https://example.org"}],
-                secrets=[{"name": "api_key", "value": "secret123"}],
-            )
-        except ConnectionError as e:
-            if "does not require any credentials" in str(e) or "not defined" in str(e):
-                self.skipTest("Test tool does not have credential definitions")
-            raise
-        assert cred is not None
+        group_name = test_util.random_string()
+        cred = self.gi.users.create_credentials(
+            user_id=user_id,
+            source_type="tool",
+            source_id=tool_id,
+            source_version=tool["version"],
+            service_name="service1",
+            service_version="v1",
+            group_name=group_name,
+            variables=[{"name": "server", "value": "https://example.org"}],
+            secrets=[{"name": "username", "value": "alice"}, {"name": "password", "value": "s3cret"}],
+        )
+        assert cred["name"] == group_name
         creds = self.gi.users.get_credentials(user_id, source_id=tool_id)
-        assert len(creds) >= 1
-        matching = [c for c in creds if c["name"] == "test_service"]
+        matching = [c for c in creds if c["name"] == "service1"]
         assert len(matching) == 1
         assert matching[0]["source_id"] == tool_id
-        assert matching[0]["version"] == "1.0"
-        assert len(matching[0]["groups"]) >= 1
+        assert matching[0]["version"] == "v1"
+        assert any(g["name"] == group_name for g in matching[0]["groups"])
 
     @test_util.skip_unless_galaxy("release_25.1")
-    @test_util.skip_unless_tool("random_lines1")
+    @test_util.skip_unless_tool("secret_tool")
     def test_get_credentials_for_tool(self):
         user_id = self.gi.users.get_current_user()["id"]
-        tool_id = "random_lines1"
+        tool_id = "secret_tool"
         tool = self.gi.tools.show_tool(tool_id)
-        try:
-            group = self.gi.users.create_credentials(
-                user_id=user_id,
-                source_type="tool",
-                source_id=tool_id,
-                source_version=tool["version"],
-                service_name="test_service_run",
-                service_version="2.0",
-                group_name="default",
-                secrets=[{"name": "token", "value": "abc123"}],
-            )
-        except ConnectionError as e:
-            if "does not require any credentials" in str(e) or "not defined" in str(e):
-                self.skipTest("Test tool does not have credential definitions")
-            raise
+        group_name = test_util.random_string()
+        group = self.gi.users.create_credentials(
+            user_id=user_id,
+            source_type="tool",
+            source_id=tool_id,
+            source_version=tool["version"],
+            service_name="service1",
+            service_version="v1",
+            group_name=group_name,
+            variables=[{"name": "server", "value": "https://example.org"}],
+            secrets=[{"name": "username", "value": "alice"}],
+        )
         # Set the active credential group (not auto-set on creation)
         creds = self.gi.users.get_credentials(user_id, source_id=tool_id)
-        matching = [c for c in creds if c["name"] == "test_service_run"]
+        matching = [c for c in creds if c["name"] == "service1"]
         self.gi.users.select_credential_group(
             user_id=user_id,
             source_type="tool",
@@ -228,14 +220,13 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         )
         context = self.gi.users.get_credentials_for_tool(user_id, tool_id, tool_version=tool["version"])
         assert context is not None
-        assert len(context) >= 1
-        entries = [e for e in context if e["name"] == "test_service_run"]
+        entries = [e for e in context if e["name"] == "service1"]
         assert len(entries) == 1
         entry = entries[0]
         assert "user_credentials_id" in entry
-        assert entry["version"] == "2.0"
-        assert "id" in entry["selected_group"]
-        assert entry["selected_group"]["name"] == "default"
+        assert entry["version"] == "v1"
+        assert entry["selected_group"]["id"] == group["id"]
+        assert entry["selected_group"]["name"] == group_name
 
     @test_util.skip_unless_galaxy("release_25.1")
     def test_get_credentials_for_tool_none(self):

--- a/bioblend/_tests/TestGalaxyUsers.py
+++ b/bioblend/_tests/TestGalaxyUsers.py
@@ -164,8 +164,8 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         assert creds == []
 
     @test_util.skip_unless_galaxy("release_25.1")
+    @test_util.skip_unless_tool("random_lines1")
     def test_create_and_get_credentials(self):
-        # Requires a Galaxy tool with credential definitions; skip if unavailable
         user_id = self.gi.users.get_current_user()["id"]
         tool_id = "random_lines1"
         tool = self.gi.tools.show_tool(tool_id)
@@ -195,8 +195,8 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         assert len(matching[0]["groups"]) >= 1
 
     @test_util.skip_unless_galaxy("release_25.1")
+    @test_util.skip_unless_tool("random_lines1")
     def test_get_credentials_for_tool(self):
-        # Requires a Galaxy tool with credential definitions; skip if unavailable
         user_id = self.gi.users.get_current_user()["id"]
         tool_id = "random_lines1"
         tool = self.gi.tools.show_tool(tool_id)

--- a/bioblend/_tests/TestGalaxyUsers.py
+++ b/bioblend/_tests/TestGalaxyUsers.py
@@ -89,7 +89,9 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         new_user_id = new_user["id"]
         updated_username = test_util.random_string()
         updated_user_email = f"{updated_username}@example.org"
-        self.gi.users.update_user(new_user_id, username=updated_username, email=updated_user_email)
+        self.gi.users.update_user(
+            new_user_id, username=updated_username, email=updated_user_email
+        )
         updated_user = self.gi.users.show_user(new_user_id)
         assert updated_user["username"] == updated_username
         assert updated_user["email"] == updated_user_email
@@ -110,7 +112,9 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         if self.gi.config.get_config()["use_remote_user"]:
             self.skipTest("This Galaxy instance is not configured to use local users")
         if not self.gi.config.get_config()["allow_user_deletion"]:
-            self.skipTest("This Galaxy instance is not configured to allow user deletion")
+            self.skipTest(
+                "This Galaxy instance is not configured to allow user deletion"
+            )
         new_username = test_util.random_string()
         new_user = self.gi.users.create_local_user(
             new_username, f"{new_username}@example.org", test_util.random_string(20)
@@ -155,4 +159,60 @@ class TestGalaxyUsers(GalaxyTestBase.GalaxyTestBase):
         assert new_apikey and new_apikey != "Not available."
         # Test regenerating an API key for a user that already has one
         regenerated_apikey = self.gi.users.create_user_apikey(new_user_id)
-        assert regenerated_apikey and regenerated_apikey not in (new_apikey, "Not available.")
+        assert regenerated_apikey and regenerated_apikey not in (
+            new_apikey,
+            "Not available.",
+        )
+
+    @test_util.skip_unless_galaxy("release_25.0")
+    def test_get_credentials_empty(self):
+        user_id = self.gi.users.get_current_user()["id"]
+        creds = self.gi.users.get_credentials(user_id, source_id="nonexistent_tool_id")
+        assert creds == []
+
+    @test_util.skip_unless_galaxy("release_25.0")
+    def test_create_and_get_credentials(self):
+        user_id = self.gi.users.get_current_user()["id"]
+        tool_id = f"test_credential_tool_{test_util.random_string()}"
+        cred = self.gi.users.create_credentials(
+            user_id=user_id,
+            source_type="tool",
+            source_id=tool_id,
+            source_version="1.0",
+            service_name="test_service",
+            service_version="1.0",
+            group_name="default",
+            variables=[{"name": "api_url", "value": "https://example.org"}],
+            secrets=[{"name": "api_key", "value": "secret123"}],
+        )
+        assert cred is not None
+        creds = self.gi.users.get_credentials(user_id, source_id=tool_id)
+        assert len(creds) == 1
+        assert creds[0]["source_id"] == tool_id
+        assert creds[0]["name"] == "test_service"
+        assert creds[0]["version"] == "1.0"
+        assert len(creds[0]["groups"]) == 1
+
+    @test_util.skip_unless_galaxy("release_25.0")
+    def test_get_credentials_for_tool(self):
+        user_id = self.gi.users.get_current_user()["id"]
+        tool_id = f"test_credential_tool_run_{test_util.random_string()}"
+        self.gi.users.create_credentials(
+            user_id=user_id,
+            source_type="tool",
+            source_id=tool_id,
+            source_version="1.0",
+            service_name="test_service",
+            service_version="2.0",
+            group_name="default",
+            secrets=[{"name": "token", "value": "abc123"}],
+        )
+        context = self.gi.users.get_credentials_for_tool(user_id, tool_id)
+        assert context is not None
+        assert len(context) == 1
+        entry = context[0]
+        assert "user_credentials_id" in entry
+        assert entry["name"] == "test_service"
+        assert entry["version"] == "2.0"
+        assert "id" in entry["selected_group"]
+        assert entry["selected_group"]["name"] == "default"

--- a/bioblend/_tests/template_galaxy.yml
+++ b/bioblend/_tests/template_galaxy.yml
@@ -18,3 +18,5 @@ galaxy:
   enable_quotas: true
   cleanup_job: onsuccess
   enable_celery_tasks: true
+  # Vault is required by the credentials API (Galaxy 25.1+)
+  vault_config_file: ${BIOBLEND_DIR}/tests/template_vault_conf.yml

--- a/bioblend/_tests/template_vault_conf.yml
+++ b/bioblend/_tests/template_vault_conf.yml
@@ -1,0 +1,5 @@
+type: database
+encryption_keys:
+  - 5RrT94ji178vQwha7TAmEix7DojtsLlxVz8Ef17KWgg=
+  - iNdXd7tRjLnSqRHxuhqQ98GTLU8HUbd5_Xx38iF8nZ0=
+  - IK83IXhE4_7W7xCFEtD9op0BAs11pJqYN236Spppp7g=

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -26,10 +26,7 @@ class ToolClient(Client):
         super().__init__(galaxy_instance)
 
     def get_tools(
-        self,
-        tool_id: str | None = None,
-        name: str | None = None,
-        trackster: bool | None = None,
+        self, tool_id: str | None = None, name: str | None = None, trackster: bool | None = None
     ) -> list[dict[str, Any]]:
         """
         Get all tools, or select a subset by specifying optional arguments for
@@ -72,9 +69,7 @@ class ToolClient(Client):
         """
         return self._raw_get_tool(in_panel=True)
 
-    def _raw_get_tool(
-        self, in_panel: bool | None = None, trackster: bool | None = None
-    ) -> list[dict[str, Any]]:
+    def _raw_get_tool(self, in_panel: bool | None = None, trackster: bool | None = None) -> list[dict[str, Any]]:
         params = {
             "in_panel": in_panel,
             "trackster": trackster,
@@ -207,9 +202,7 @@ class ToolClient(Client):
         ht_response = self._get(url=raw_source_url, json=False)
         return ht_response.text
 
-    def show_tool(
-        self, tool_id: str, io_details: bool = False, link_details: bool = False
-    ) -> dict[str, Any]:
+    def show_tool(self, tool_id: str, io_details: bool = False, link_details: bool = False) -> dict[str, Any]:
         """
         Get details of a given tool.
 
@@ -231,9 +224,7 @@ class ToolClient(Client):
         }
         return self._get(id=tool_id, params=params)
 
-    def get_tool_tests(
-        self, tool_id: str, tool_version: str | None = None
-    ) -> list[dict[str, Any]]:
+    def get_tool_tests(self, tool_id: str, tool_version: str | None = None) -> list[dict[str, Any]]:
         """
         Fetch the test case definitions configured for a tool.
 
@@ -562,9 +553,7 @@ class ToolClient(Client):
         """
         if self.gi.config.get_version()["version_major"] >= "22.01":
             # Use the tus protocol
-            uploader = self.gi.get_tus_uploader(
-                path, storage=storage, metadata=metadata, chunk_size=chunk_size
-            )
+            uploader = self.gi.get_tus_uploader(path, storage=storage, metadata=metadata, chunk_size=chunk_size)
             uploader.upload()
             return self.post_to_fetch(path, history_id, uploader.session_id, **kwargs)
         else:
@@ -577,9 +566,7 @@ class ToolClient(Client):
             finally:
                 payload["files_0|file_data"].close()
 
-    def post_to_fetch(
-        self, path: str, history_id: str, session_id: str, **kwargs: Any
-    ) -> dict[str, Any]:
+    def post_to_fetch(self, path: str, history_id: str, session_id: str, **kwargs: Any) -> dict[str, Any]:
         """
         Make a POST request to the Fetch API after performing a tus upload.
 
@@ -605,9 +592,7 @@ class ToolClient(Client):
         url = "/".join((self.gi.url, "tools/fetch"))
         return self._post(payload, url=url)
 
-    def upload_from_ftp(
-        self, path: str, history_id: str, **kwargs: Any
-    ) -> dict[str, Any]:
+    def upload_from_ftp(self, path: str, history_id: str, **kwargs: Any) -> dict[str, Any]:
         """
         Upload the file specified by ``path`` from the user's FTP directory to
         the history specified by ``history_id``.
@@ -627,9 +612,7 @@ class ToolClient(Client):
         payload["files_0|ftp_files"] = path
         return self._post(payload)
 
-    def paste_content(
-        self, content: str, history_id: str, **kwargs: Any
-    ) -> dict[str, Any]:
+    def paste_content(self, content: str, history_id: str, **kwargs: Any) -> dict[str, Any]:
         """
         Upload a string to a new dataset in the history specified by
         ``history_id``.
@@ -670,9 +653,7 @@ class ToolClient(Client):
             "inputs": tool_input,
         }
 
-    def _fetch_payload(
-        self, path: str, history_id: str, session_id: str, **kwargs: Any
-    ) -> dict:
+    def _fetch_payload(self, path: str, history_id: str, session_id: str, **kwargs: Any) -> dict:
         file_name = kwargs.get("file_name", basename(path))
         element = {
             "src": "files",

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -26,7 +26,10 @@ class ToolClient(Client):
         super().__init__(galaxy_instance)
 
     def get_tools(
-        self, tool_id: str | None = None, name: str | None = None, trackster: bool | None = None
+        self,
+        tool_id: str | None = None,
+        name: str | None = None,
+        trackster: bool | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get all tools, or select a subset by specifying optional arguments for
@@ -69,7 +72,9 @@ class ToolClient(Client):
         """
         return self._raw_get_tool(in_panel=True)
 
-    def _raw_get_tool(self, in_panel: bool | None = None, trackster: bool | None = None) -> list[dict[str, Any]]:
+    def _raw_get_tool(
+        self, in_panel: bool | None = None, trackster: bool | None = None
+    ) -> list[dict[str, Any]]:
         params = {
             "in_panel": in_panel,
             "trackster": trackster,
@@ -202,7 +207,9 @@ class ToolClient(Client):
         ht_response = self._get(url=raw_source_url, json=False)
         return ht_response.text
 
-    def show_tool(self, tool_id: str, io_details: bool = False, link_details: bool = False) -> dict[str, Any]:
+    def show_tool(
+        self, tool_id: str, io_details: bool = False, link_details: bool = False
+    ) -> dict[str, Any]:
         """
         Get details of a given tool.
 
@@ -224,7 +231,9 @@ class ToolClient(Client):
         }
         return self._get(id=tool_id, params=params)
 
-    def get_tool_tests(self, tool_id: str, tool_version: str | None = None) -> list[dict[str, Any]]:
+    def get_tool_tests(
+        self, tool_id: str, tool_version: str | None = None
+    ) -> list[dict[str, Any]]:
         """
         Fetch the test case definitions configured for a tool.
 
@@ -474,7 +483,7 @@ class ToolClient(Client):
         You can also check the examples in `Galaxy's API test suite
         <https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy_test/api/test_tools.py>`_.
         """
-        payload: dict[str, str | dict] = {
+        payload: dict[str, Any] = {
             "history_id": history_id,
             "tool_id": tool_id,
             "input_format": input_format,
@@ -553,7 +562,9 @@ class ToolClient(Client):
         """
         if self.gi.config.get_version()["version_major"] >= "22.01":
             # Use the tus protocol
-            uploader = self.gi.get_tus_uploader(path, storage=storage, metadata=metadata, chunk_size=chunk_size)
+            uploader = self.gi.get_tus_uploader(
+                path, storage=storage, metadata=metadata, chunk_size=chunk_size
+            )
             uploader.upload()
             return self.post_to_fetch(path, history_id, uploader.session_id, **kwargs)
         else:
@@ -566,7 +577,9 @@ class ToolClient(Client):
             finally:
                 payload["files_0|file_data"].close()
 
-    def post_to_fetch(self, path: str, history_id: str, session_id: str, **kwargs: Any) -> dict[str, Any]:
+    def post_to_fetch(
+        self, path: str, history_id: str, session_id: str, **kwargs: Any
+    ) -> dict[str, Any]:
         """
         Make a POST request to the Fetch API after performing a tus upload.
 
@@ -592,7 +605,9 @@ class ToolClient(Client):
         url = "/".join((self.gi.url, "tools/fetch"))
         return self._post(payload, url=url)
 
-    def upload_from_ftp(self, path: str, history_id: str, **kwargs: Any) -> dict[str, Any]:
+    def upload_from_ftp(
+        self, path: str, history_id: str, **kwargs: Any
+    ) -> dict[str, Any]:
         """
         Upload the file specified by ``path`` from the user's FTP directory to
         the history specified by ``history_id``.
@@ -612,7 +627,9 @@ class ToolClient(Client):
         payload["files_0|ftp_files"] = path
         return self._post(payload)
 
-    def paste_content(self, content: str, history_id: str, **kwargs: Any) -> dict[str, Any]:
+    def paste_content(
+        self, content: str, history_id: str, **kwargs: Any
+    ) -> dict[str, Any]:
         """
         Upload a string to a new dataset in the history specified by
         ``history_id``.
@@ -653,7 +670,9 @@ class ToolClient(Client):
             "inputs": tool_input,
         }
 
-    def _fetch_payload(self, path: str, history_id: str, session_id: str, **kwargs: Any) -> dict:
+    def _fetch_payload(
+        self, path: str, history_id: str, session_id: str, **kwargs: Any
+    ) -> dict:
         file_name = kwargs.get("file_name", basename(path))
         element = {
             "src": "files",

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -383,6 +383,7 @@ class ToolClient(Client):
         tool_inputs: InputsBuilder | dict,
         input_format: Literal["21.01", "legacy"] = "legacy",
         data_manager_mode: Literal["populate", "dry_run", "bundle"] | None = None,
+        credentials_context: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """
         Runs tool specified by ``tool_id`` in history indicated
@@ -403,6 +404,13 @@ class ToolClient(Client):
           'dry_run' will skip any processing after the data manager job completes
 
           'bundle' will create a data manager bundle that can be imported on other Galaxy servers.
+
+        :type credentials_context: list of dicts
+        :param credentials_context: list of credential context dicts for tools
+          that require credentials (e.g. API keys). Each dict should contain
+          ``user_credentials_id``, ``name``, ``version``, and ``selected_group``
+          (with ``id`` and ``name`` keys). Obtain credential IDs by storing
+          credentials via the Galaxy credentials API first.
 
         :type tool_inputs: dict
         :param tool_inputs: dictionary of input datasets and parameters
@@ -479,6 +487,9 @@ class ToolClient(Client):
 
         if data_manager_mode:
             payload["data_manager_mode"] = data_manager_mode
+
+        if credentials_context:
+            payload["credentials_context"] = credentials_context
 
         return self._post(payload)
 

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -497,7 +497,7 @@ class ToolClient(Client):
         if data_manager_mode:
             payload["data_manager_mode"] = data_manager_mode
 
-        if credentials_context:
+        if credentials_context is not None:
             payload["credentials_context"] = credentials_context
 
         return self._post(payload)

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -110,7 +110,9 @@ class UserClient(Client):
         }
         return self._post(payload)
 
-    def create_local_user(self, username: str, user_email: str, password: str) -> dict[str, Any]:
+    def create_local_user(
+        self, username: str, user_email: str, password: str
+    ) -> dict[str, Any]:
         """
         Create a new Galaxy local user.
 
@@ -229,7 +231,9 @@ class UserClient(Client):
         url = self._make_url(user_id) + "/api_key"
         return self._get(url=url)
 
-    def update_user(self, user_id: str, user_data: dict | None = None, **kwargs: Any) -> dict[str, Any]:
+    def update_user(
+        self, user_id: str, user_data: dict | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
         """
         Update user information. You can either pass the attributes you want to
         change in the user_data dictionary, or provide them separately as
@@ -375,20 +379,30 @@ class UserClient(Client):
         :rtype: list of dicts or None
         :return: credentials_context list for run_tool(), or None
         """
-        creds = self.get_credentials(user_id, source_type="tool", source_id=tool_id, source_version=tool_version)
+        creds = self.get_credentials(
+            user_id, source_type="tool", source_id=tool_id, source_version=tool_version
+        )
         if not creds:
             return None
         context = []
         for cred in creds:
-            current_group = cred.get("current_group")
-            if current_group:
-                context.append({
+            current_group_id = cred.get("current_group_id")
+            if not current_group_id:
+                continue
+            group_name = "default"
+            for group in cred.get("groups", []):
+                if group["id"] == current_group_id:
+                    group_name = group.get("name", "default")
+                    break
+            context.append(
+                {
                     "user_credentials_id": cred["id"],
-                    "name": cred.get("service_name", ""),
-                    "version": cred.get("service_version", ""),
+                    "name": cred.get("name", ""),
+                    "version": cred.get("version", ""),
                     "selected_group": {
-                        "id": current_group["id"],
-                        "name": current_group.get("name", "default"),
+                        "id": current_group_id,
+                        "name": group_name,
                     },
-                })
+                }
+            )
         return context if context else None

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -257,3 +257,138 @@ class UserClient(Client):
         user_data.update(kwargs)
         url = self._make_url(user_id) + "/information/inputs"
         return self._put(url=url, payload=user_data, id=user_id)
+
+    def get_credentials(
+        self,
+        user_id: str,
+        source_type: str = "tool",
+        source_id: str | None = None,
+        source_version: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Get stored credentials for a user, optionally filtered by tool.
+
+        :type user_id: str
+        :param user_id: encoded user ID
+
+        :type source_type: str
+        :param source_type: credential source type (default: 'tool')
+
+        :type source_id: str
+        :param source_id: tool ID to filter by
+
+        :type source_version: str
+        :param source_version: tool version to filter by
+
+        :rtype: list of dicts
+        :return: list of stored credentials
+        """
+        url = self._make_url(user_id) + "/credentials"
+        params: dict[str, str] = {"source_type": source_type}
+        if source_id:
+            params["source_id"] = source_id
+        if source_version:
+            params["source_version"] = source_version
+        return self._get(url=url, params=params)
+
+    def create_credentials(
+        self,
+        user_id: str,
+        source_type: str,
+        source_id: str,
+        source_version: str,
+        service_name: str,
+        service_version: str,
+        group_name: str,
+        variables: list[dict[str, str]] | None = None,
+        secrets: list[dict[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Store credentials for a user (e.g. API keys for external services).
+
+        :type user_id: str
+        :param user_id: encoded user ID
+
+        :type source_type: str
+        :param source_type: credential source type (e.g. 'tool')
+
+        :type source_id: str
+        :param source_id: tool ID
+
+        :type source_version: str
+        :param source_version: tool version
+
+        :type service_name: str
+        :param service_name: name of the credential service
+
+        :type service_version: str
+        :param service_version: version of the credential service
+
+        :type group_name: str
+        :param group_name: name for the credential group
+
+        :type variables: list of dicts
+        :param variables: list of variable dicts with 'name' and 'value' keys
+
+        :type secrets: list of dicts
+        :param secrets: list of secret dicts with 'name' and 'value' keys
+
+        :rtype: dict
+        :return: the created credentials
+        """
+        url = self._make_url(user_id) + "/credentials"
+        payload = {
+            "source_type": source_type,
+            "source_id": source_id,
+            "source_version": source_version,
+            "service_credential": {
+                "name": service_name,
+                "version": service_version,
+                "group": {
+                    "name": group_name,
+                    "variables": variables or [],
+                    "secrets": secrets or [],
+                },
+            },
+        }
+        return self._post(url=url, payload=payload)
+
+    def get_credentials_for_tool(
+        self,
+        user_id: str,
+        tool_id: str,
+        tool_version: str | None = None,
+    ) -> list[dict[str, Any]] | None:
+        """
+        Build a credentials_context list suitable for passing to
+        ``tools.run_tool()``. Returns None if no credentials are stored.
+
+        :type user_id: str
+        :param user_id: encoded user ID
+
+        :type tool_id: str
+        :param tool_id: tool ID to look up credentials for
+
+        :type tool_version: str
+        :param tool_version: tool version
+
+        :rtype: list of dicts or None
+        :return: credentials_context list for run_tool(), or None
+        """
+        creds = self.get_credentials(user_id, source_type="tool", source_id=tool_id, source_version=tool_version)
+        if not creds:
+            return None
+        context = []
+        for cred in creds:
+            current_group = cred.get("current_group")
+            if current_group:
+                context.append({
+                    "user_credentials_id": cred["id"],
+                    "name": cred.get("service_name", ""),
+                    "version": cred.get("service_version", ""),
+                    "selected_group": {
+                        "id": current_group["id"],
+                        "name": current_group.get("name", "default"),
+                    },
+                })
+        return context if context else None

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -289,9 +289,9 @@ class UserClient(Client):
         """
         url = self._make_url(user_id) + "/credentials"
         params: dict[str, str] = {"source_type": source_type}
-        if source_id:
+        if source_id is not None:
             params["source_id"] = source_id
-        if source_version:
+        if source_version is not None:
             params["source_version"] = source_version
         return self._get(url=url, params=params)
 
@@ -329,7 +329,7 @@ class UserClient(Client):
         :param service_version: version of the credential service
 
         :type group_name: str
-        :param group_name: name for the credential group
+        :param group_name: name for the credential group (minimum 3 characters)
 
         :type variables: list of dicts
         :param variables: list of variable dicts with 'name' and 'value' keys
@@ -338,7 +338,8 @@ class UserClient(Client):
         :param secrets: list of secret dicts with 'name' and 'value' keys
 
         :rtype: dict
-        :return: the created credentials
+        :return: the created credential group (with ``id``, ``name``,
+          ``variables``, ``secrets``, and ``update_time``)
         """
         url = self._make_url(user_id) + "/credentials"
         payload = {
@@ -356,6 +357,58 @@ class UserClient(Client):
             },
         }
         return self._post(url=url, payload=payload)
+
+    def select_credential_group(
+        self,
+        user_id: str,
+        source_type: str,
+        source_id: str,
+        source_version: str,
+        user_credentials_id: str,
+        group_id: str | None,
+    ) -> None:
+        """
+        Select the active credential group for a set of user credentials.
+        This must be called after ``create_credentials()`` before the
+        credentials can be used with ``run_tool()``.
+
+        :type user_id: str
+        :param user_id: encoded user ID
+
+        :type source_type: str
+        :param source_type: credential source type (e.g. 'tool')
+
+        :type source_id: str
+        :param source_id: tool ID
+
+        :type source_version: str
+        :param source_version: tool version
+
+        :type user_credentials_id: str
+        :param user_credentials_id: encoded ID of the user credentials entry
+
+        :type group_id: str or None
+        :param group_id: encoded ID of the credential group to activate,
+          or ``None`` to unset
+        """
+        url = self._make_url(user_id) + "/credentials"
+        payload = {
+            "source_type": source_type,
+            "source_id": source_id,
+            "source_version": source_version,
+            "service_credentials": [
+                {
+                    "user_credentials_id": user_credentials_id,
+                    "current_group_id": group_id,
+                },
+            ],
+        }
+        try:
+            self._put(url=url, payload=payload)
+        except ConnectionError as e:
+            if e.status_code == 204:
+                return None
+            raise
 
     def get_credentials_for_tool(
         self,

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -365,7 +365,7 @@ class UserClient(Client):
     ) -> None:
         """
         Select the active credential group for a set of user credentials.
-        This must be called after ``create_credentials()`` before the
+        This must be called after credentials have been created but before the
         credentials can be used with ``run_tool()``.
 
         :type user_id: str

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -110,9 +110,7 @@ class UserClient(Client):
         }
         return self._post(payload)
 
-    def create_local_user(
-        self, username: str, user_email: str, password: str
-    ) -> dict[str, Any]:
+    def create_local_user(self, username: str, user_email: str, password: str) -> dict[str, Any]:
         """
         Create a new Galaxy local user.
 
@@ -231,9 +229,7 @@ class UserClient(Client):
         url = self._make_url(user_id) + "/api_key"
         return self._get(url=url)
 
-    def update_user(
-        self, user_id: str, user_data: dict | None = None, **kwargs: Any
-    ) -> dict[str, Any]:
+    def update_user(self, user_id: str, user_data: dict | None = None, **kwargs: Any) -> dict[str, Any]:
         """
         Update user information. You can either pass the attributes you want to
         change in the user_data dictionary, or provide them separately as
@@ -432,9 +428,7 @@ class UserClient(Client):
         :rtype: list of dicts or None
         :return: credentials_context list for run_tool(), or None
         """
-        creds = self.get_credentials(
-            user_id, source_type="tool", source_id=tool_id, source_version=tool_version
-        )
+        creds = self.get_credentials(user_id, source_type="tool", source_id=tool_id, source_version=tool_version)
         if not creds:
             return None
         context = []

--- a/bioblend/galaxy/users/__init__.py
+++ b/bioblend/galaxy/users/__init__.py
@@ -434,21 +434,19 @@ class UserClient(Client):
         context = []
         for cred in creds:
             current_group_id = cred.get("current_group_id")
-            if not current_group_id:
+            if current_group_id is None:
                 continue
-            group_name = "default"
-            for group in cred.get("groups", []):
-                if group["id"] == current_group_id:
-                    group_name = group.get("name", "default")
-                    break
+            current_group = next((g for g in cred["groups"] if g["id"] == current_group_id), None)
+            if current_group is None:
+                continue
             context.append(
                 {
                     "user_credentials_id": cred["id"],
-                    "name": cred.get("name", ""),
-                    "version": cred.get("version", ""),
+                    "name": cred["name"],
+                    "version": cred["version"],
                     "selected_group": {
                         "id": current_group_id,
-                        "name": group_name,
+                        "name": current_group["name"],
                     },
                 }
             )


### PR DESCRIPTION
## Summary

- Add `get_credentials`, `create_credentials`, `select_credential_group`, and `get_credentials_for_tool` methods to `UserClient` wrapping Galaxy's `/api/users/{id}/credentials` endpoints
- Add `credentials_context` parameter to `ToolClient.run_tool()` for passing stored credentials when executing tools that require them
- `get_credentials_for_tool` is a convenience method that builds the `credentials_context` list from stored credentials, ready to pass directly to `run_tool()`

## Test plan

- [ ] Integration tests added for all credential methods (gated on `release_25.1`)
- [ ] Verify `create_credentials` + `select_credential_group` + `get_credentials_for_tool` + `run_tool(credentials_context=...)` workflow against a Galaxy instance with credential support
- [ ] `ruff check` and `ruff format` pass