### PR TITLE
Add UnprivilegedToolsClient and tool_uuid support on run_tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## BioBlend v1.10.0 - unreleased
 
 * Added ``UnprivilegedToolsClient`` with ``create_user_tool()``,
-  ``get_user_tools()``, ``show_user_tool()``, ``delete_user_tool()``, and
-  ``run_user_tool()`` methods for managing and running user-defined tools
-  via the ``/api/unprivileged_tools`` endpoints (thanks to
+  ``get_user_tools()``, ``show_user_tool()``, and ``delete_user_tool()``
+  methods for managing user-defined tools via the
+  ``/api/unprivileged_tools`` endpoints (thanks to
+  [Dannon Baker](https://github.com/dannon)).
+
+* Added ``tool_uuid`` and ``tool_version`` parameters to
+  ``ToolClient.run_tool()`` so unprivileged user tools can be run by UUID.
+  ``tool_id`` is now optional; exactly one of ``tool_id`` or ``tool_uuid``
+  must be provided (thanks to
   [Dannon Baker](https://github.com/dannon)).
 
 ## BioBlend v1.9.0 - 2026-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## BioBlend v1.10.0 - unreleased
+
+* Added ``UnprivilegedToolsClient`` with ``create_user_tool()``,
+  ``get_user_tools()``, ``show_user_tool()``, ``delete_user_tool()``, and
+  ``run_user_tool()`` methods for managing and running user-defined tools
+  via the ``/api/unprivileged_tools`` endpoints (thanks to
+  [Dannon Baker](https://github.com/dannon)).
+
 ## BioBlend v1.9.0 - 2026-04-14
 
 * Added ``create_credentials()``, ``get_credentials()``,

--- a/bioblend/_tests/TestGalaxyUnprivilegedTools.py
+++ b/bioblend/_tests/TestGalaxyUnprivilegedTools.py
@@ -1,0 +1,73 @@
+""" """
+
+import unittest
+
+from . import GalaxyTestBase
+
+# Minimal user-tool representation (mirrors TOOL_WITH_SHELL_COMMAND from
+# galaxy_test.base.populators). Galaxy must allow the test user to run
+# unprivileged tools for these tests to succeed; otherwise create returns
+# a payload with ``err_msg`` and we skip.
+USER_TOOL_REPRESENTATION = {
+    "id": "bioblend_test_basecommand",
+    "name": "BioBlend test base command tool",
+    "class": "GalaxyUserTool",
+    "container": "busybox",
+    "version": "1.0.0",
+    "shell_command": "cat '$(inputs.input.path)' > output.txt",
+    "inputs": [
+        {
+            "type": "data",
+            "name": "input",
+            "format": "txt",
+        }
+    ],
+    "outputs": [
+        {
+            "type": "data",
+            "from_work_dir": "output.txt",
+            "name": "output",
+        }
+    ],
+}
+
+
+class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
+    def setUp(self):
+        super().setUp()
+        created = self.gi.unprivileged_tools.create_user_tool(USER_TOOL_REPRESENTATION)
+        if "err_msg" in created:
+            raise unittest.SkipTest(f"Galaxy did not accept the unprivileged tool: {created['err_msg']}")
+        self.tool_uuid = created["uuid"]
+
+    def tearDown(self):
+        try:
+            self.gi.unprivileged_tools.delete_user_tool(self.tool_uuid)
+        except Exception:
+            # Best-effort cleanup -- tool may already be deactivated by a test.
+            pass
+
+    def test_create_user_tool(self):
+        tool = self.gi.unprivileged_tools.show_user_tool(self.tool_uuid)
+        assert tool["uuid"] == self.tool_uuid
+        assert tool["representation"]["name"] == USER_TOOL_REPRESENTATION["name"]
+
+    def test_get_user_tools(self):
+        active = self.gi.unprivileged_tools.get_user_tools(active=True)
+        assert any(t["uuid"] == self.tool_uuid for t in active)
+
+    def test_delete_user_tool(self):
+        self.gi.unprivileged_tools.delete_user_tool(self.tool_uuid)
+        active = self.gi.unprivileged_tools.get_user_tools(active=True)
+        assert not any(t["uuid"] == self.tool_uuid for t in active)
+
+    def test_run_user_tool(self):
+        history = self.gi.histories.create_history(name="test_run_user_tool history")
+        dataset_id = self._test_dataset(history["id"], contents="abc\n")
+        result = self.gi.unprivileged_tools.run_user_tool(
+            history_id=history["id"],
+            tool_uuid=self.tool_uuid,
+            tool_inputs={"input": {"src": "hda", "id": dataset_id}},
+        )
+        assert "jobs" in result
+        assert len(result["jobs"]) > 0

--- a/bioblend/_tests/TestGalaxyUnprivilegedTools.py
+++ b/bioblend/_tests/TestGalaxyUnprivilegedTools.py
@@ -70,7 +70,7 @@ class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
     def test_run_user_tool(self):
         history = self.gi.histories.create_history(name="test_run_user_tool history")
         dataset_id = self._test_dataset(history["id"], contents="abc\n")
-        result = self.gi.unprivileged_tools.run_user_tool(
+        result = self.gi.tools.run_tool(
             history_id=history["id"],
             tool_uuid=self.tool_uuid,
             tool_inputs={"input": {"src": "hda", "id": dataset_id}},

--- a/bioblend/_tests/TestGalaxyUnprivilegedTools.py
+++ b/bioblend/_tests/TestGalaxyUnprivilegedTools.py
@@ -1,16 +1,18 @@
 """ """
 
+import os
 import unittest
 
 import bioblend
+from bioblend.galaxy import GalaxyInstance
 from . import (
     GalaxyTestBase,
     test_util,
 )
 
 # Minimal user-tool representation (mirrors TOOL_WITH_SHELL_COMMAND from
-# galaxy_test.base.populators). Requires the test user to be granted the
-# USER_TOOL_EXECUTE role in Galaxy; otherwise the tests skip.
+# galaxy_test.base.populators). Running the tool requires a container
+# runtime (busybox); the run test is gated on that.
 USER_TOOL_REPRESENTATION = {
     "id": "bioblend_test_basecommand",
     "name": "BioBlend test base command tool",
@@ -37,18 +39,47 @@ USER_TOOL_REPRESENTATION = {
 
 @test_util.skip_unless_galaxy("release_25.0")
 class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
+    admin_gi: GalaxyInstance
+    role_id: str
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        master_key = os.environ.get("BIOBLEND_GALAXY_MASTER_API_KEY")
+        if not master_key:
+            raise unittest.SkipTest(
+                "BIOBLEND_GALAXY_MASTER_API_KEY is required to grant the test user the user_tool_execute role."
+            )
+        cls.admin_gi = GalaxyInstance(url=os.environ["BIOBLEND_GALAXY_URL"], key=master_key)
+        user_id = cls.gi.users.get_current_user()["id"]
+        payload = {
+            "name": f"bioblend_user_tool_execute_{user_id}",
+            "description": "BioBlend test role granting user_tool_execute",
+            "role_type": "user_tool_execute",
+            "user_ids": [user_id],
+            "group_ids": [],
+        }
+        role = cls.admin_gi.make_post_request(f"{cls.admin_gi.url}/roles", payload=payload)
+        cls.role_id = role[0]["id"] if isinstance(role, list) else role["id"]
+
+    @classmethod
+    def tearDownClass(cls):
+        role_id = getattr(cls, "role_id", None)
+        if role_id:
+            try:
+                cls.admin_gi.make_delete_request(f"{cls.admin_gi.url}/roles/{role_id}")
+                cls.admin_gi.make_post_request(f"{cls.admin_gi.url}/roles/{role_id}/purge", payload={})
+            except bioblend.ConnectionError:
+                pass
+
     def setUp(self):
         super().setUp()
-        try:
-            created = self.gi.unprivileged_tools.create_user_tool(USER_TOOL_REPRESENTATION)
-        except bioblend.ConnectionError as e:
-            if e.status_code in (401, 403):
-                raise unittest.SkipTest(f"User lacks permission to run unprivileged tools: {e}")
-            raise
-        self.tool_uuid = created["uuid"]
+        created = self.gi.unprivileged_tools.create_user_tool(USER_TOOL_REPRESENTATION)
+        self.tool_uuid: str = created["uuid"]
+        self._tool_deleted = False
 
     def tearDown(self):
-        if self.tool_uuid is None:
+        if self._tool_deleted:
             return
         try:
             self.gi.unprivileged_tools.delete_user_tool(self.tool_uuid)
@@ -65,12 +96,15 @@ class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
         assert any(t["uuid"] == self.tool_uuid for t in active)
 
     def test_delete_user_tool(self):
-        uuid = self.tool_uuid
-        self.gi.unprivileged_tools.delete_user_tool(uuid)
-        self.tool_uuid = None
+        self.gi.unprivileged_tools.delete_user_tool(self.tool_uuid)
+        self._tool_deleted = True
         active = self.gi.unprivileged_tools.get_user_tools(active=True)
-        assert not any(t["uuid"] == uuid for t in active)
+        assert not any(t["uuid"] == self.tool_uuid for t in active)
 
+    @unittest.skipUnless(
+        os.environ.get("BIOBLEND_TEST_CONTAINER_RUNTIME"),
+        "Set BIOBLEND_TEST_CONTAINER_RUNTIME=1 when docker/singularity is available",
+    )
     def test_run_user_tool(self):
         history = self.gi.histories.create_history(name="test_run_user_tool history")
         dataset_id = self._test_dataset(history["id"], contents="abc\n")

--- a/bioblend/_tests/TestGalaxyUnprivilegedTools.py
+++ b/bioblend/_tests/TestGalaxyUnprivilegedTools.py
@@ -3,7 +3,10 @@
 import unittest
 
 import bioblend
-from . import GalaxyTestBase
+from . import (
+    GalaxyTestBase,
+    test_util,
+)
 
 # Minimal user-tool representation (mirrors TOOL_WITH_SHELL_COMMAND from
 # galaxy_test.base.populators). Requires the test user to be granted the
@@ -32,6 +35,7 @@ USER_TOOL_REPRESENTATION = {
 }
 
 
+@test_util.skip_unless_galaxy("release_25.0")
 class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
     def setUp(self):
         super().setUp()

--- a/bioblend/_tests/TestGalaxyUnprivilegedTools.py
+++ b/bioblend/_tests/TestGalaxyUnprivilegedTools.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+import bioblend
 from . import GalaxyTestBase
 
 # Minimal user-tool representation (mirrors TOOL_WITH_SHELL_COMMAND from
@@ -41,10 +42,11 @@ class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
         self.tool_uuid = created["uuid"]
 
     def tearDown(self):
+        if self.tool_uuid is None:
+            return
         try:
             self.gi.unprivileged_tools.delete_user_tool(self.tool_uuid)
-        except Exception:
-            # Best-effort cleanup -- tool may already be deactivated by a test.
+        except bioblend.ConnectionError:
             pass
 
     def test_create_user_tool(self):
@@ -57,9 +59,11 @@ class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
         assert any(t["uuid"] == self.tool_uuid for t in active)
 
     def test_delete_user_tool(self):
-        self.gi.unprivileged_tools.delete_user_tool(self.tool_uuid)
+        uuid = self.tool_uuid
+        self.gi.unprivileged_tools.delete_user_tool(uuid)
+        self.tool_uuid = None
         active = self.gi.unprivileged_tools.get_user_tools(active=True)
-        assert not any(t["uuid"] == self.tool_uuid for t in active)
+        assert not any(t["uuid"] == uuid for t in active)
 
     def test_run_user_tool(self):
         history = self.gi.histories.create_history(name="test_run_user_tool history")

--- a/bioblend/_tests/TestGalaxyUnprivilegedTools.py
+++ b/bioblend/_tests/TestGalaxyUnprivilegedTools.py
@@ -6,9 +6,8 @@ import bioblend
 from . import GalaxyTestBase
 
 # Minimal user-tool representation (mirrors TOOL_WITH_SHELL_COMMAND from
-# galaxy_test.base.populators). Galaxy must allow the test user to run
-# unprivileged tools for these tests to succeed; otherwise create returns
-# a payload with ``err_msg`` and we skip.
+# galaxy_test.base.populators). Requires the test user to be granted the
+# USER_TOOL_EXECUTE role in Galaxy; otherwise the tests skip.
 USER_TOOL_REPRESENTATION = {
     "id": "bioblend_test_basecommand",
     "name": "BioBlend test base command tool",
@@ -36,9 +35,12 @@ USER_TOOL_REPRESENTATION = {
 class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
     def setUp(self):
         super().setUp()
-        created = self.gi.unprivileged_tools.create_user_tool(USER_TOOL_REPRESENTATION)
-        if "err_msg" in created:
-            raise unittest.SkipTest(f"Galaxy did not accept the unprivileged tool: {created['err_msg']}")
+        try:
+            created = self.gi.unprivileged_tools.create_user_tool(USER_TOOL_REPRESENTATION)
+        except bioblend.ConnectionError as e:
+            if e.status_code in (401, 403):
+                raise unittest.SkipTest(f"User lacks permission to run unprivileged tools: {e}")
+            raise
         self.tool_uuid = created["uuid"]
 
     def tearDown(self):

--- a/bioblend/_tests/TestGalaxyUnprivilegedTools.py
+++ b/bioblend/_tests/TestGalaxyUnprivilegedTools.py
@@ -74,7 +74,15 @@ class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
 
     def setUp(self):
         super().setUp()
-        created = self.gi.unprivileged_tools.create_user_tool(USER_TOOL_REPRESENTATION)
+        try:
+            created = self.gi.unprivileged_tools.create_user_tool(USER_TOOL_REPRESENTATION)
+        except bioblend.ConnectionError as e:
+            # Galaxy refuses dynamic tool creation unless enable_beta_tool_formats
+            # is set server-side (err_code 403004). Skip rather than fail when
+            # pointed at a server that lacks the flag; bioblend's own CI enables it.
+            if e.status_code == 403 and "403004" in str(e.body):
+                raise unittest.SkipTest("Galaxy server lacks enable_beta_tool_formats; cannot create user tools.")
+            raise
         self.tool_uuid: str = created["uuid"]
         self._tool_deleted = False
 

--- a/bioblend/_tests/TestGalaxyUnprivilegedTools.py
+++ b/bioblend/_tests/TestGalaxyUnprivilegedTools.py
@@ -60,7 +60,7 @@ class TestGalaxyUnprivilegedTools(GalaxyTestBase.GalaxyTestBase):
             "group_ids": [],
         }
         role = cls.admin_gi.make_post_request(f"{cls.admin_gi.url}/roles", payload=payload)
-        cls.role_id = role[0]["id"] if isinstance(role, list) else role["id"]
+        cls.role_id = role["id"]
 
     @classmethod
     def tearDownClass(cls):

--- a/bioblend/_tests/template_galaxy.yml
+++ b/bioblend/_tests/template_galaxy.yml
@@ -14,6 +14,8 @@ galaxy:
   admin_users: $BIOBLEND_GALAXY_USER_EMAIL
   allow_user_deletion: true
   enable_beta_workflow_modules: true
+  # Required to create dynamic/unprivileged tools (Galaxy 25.0+)
+  enable_beta_tool_formats: true
   master_api_key: $BIOBLEND_GALAXY_MASTER_API_KEY
   enable_quotas: true
   cleanup_job: onsuccess

--- a/bioblend/galaxy/__init__.py
+++ b/bioblend/galaxy/__init__.py
@@ -23,6 +23,7 @@ from bioblend.galaxy import (
     tool_dependencies,
     tools,
     toolshed,
+    unprivileged_tools,
     users,
     visual,
     workflows,
@@ -116,6 +117,7 @@ class GalaxyInstance(GalaxyClient):
         self.tool_data = tool_data.ToolDataClient(self)
         self.folders = folders.FoldersClient(self)
         self.tool_dependencies = tool_dependencies.ToolDependenciesClient(self)
+        self.unprivileged_tools = unprivileged_tools.UnprivilegedToolsClient(self)
 
     def __repr__(self) -> str:
         """

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -379,21 +379,32 @@ class ToolClient(Client):
     def run_tool(
         self,
         history_id: str,
-        tool_id: str,
-        tool_inputs: InputsBuilder | dict,
+        tool_id: str | None = None,
+        tool_inputs: InputsBuilder | dict | None = None,
         input_format: Literal["21.01", "legacy"] = "legacy",
         data_manager_mode: Literal["populate", "dry_run", "bundle"] | None = None,
         credentials_context: list[dict[str, Any]] | None = None,
+        tool_uuid: str | None = None,
+        tool_version: str | None = None,
     ) -> dict[str, Any]:
         """
-        Runs tool specified by ``tool_id`` in history indicated
-        by ``history_id`` with inputs from ``dict`` ``tool_inputs``.
+        Runs the tool specified by ``tool_id`` (or ``tool_uuid`` for an
+        unprivileged user tool) in the history indicated by ``history_id``
+        with inputs from ``dict`` ``tool_inputs``.
 
         :type history_id: str
         :param history_id: encoded ID of the history in which to run the tool
 
         :type tool_id: str
-        :param tool_id: ID of the tool to be run
+        :param tool_id: ID of the tool to be run. Mutually exclusive with
+          ``tool_uuid``; one of the two must be provided.
+
+        :type tool_uuid: str
+        :param tool_uuid: UUID of an unprivileged user tool to run. Mutually
+          exclusive with ``tool_id``.
+
+        :type tool_version: str
+        :param tool_version: Optional tool version to pin the run to.
 
         :type data_manager_mode: str
         :param data_manager_mode: Possible values are 'populate', 'dry_run' and 'bundle'.
@@ -474,11 +485,21 @@ class ToolClient(Client):
         You can also check the examples in `Galaxy's API test suite
         <https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy_test/api/test_tools.py>`_.
         """
+        if (tool_id is None) == (tool_uuid is None):
+            raise ValueError("Exactly one of tool_id or tool_uuid must be provided.")
+        if tool_inputs is None:
+            raise ValueError("tool_inputs is required.")
+
         payload: dict[str, Any] = {
             "history_id": history_id,
-            "tool_id": tool_id,
             "input_format": input_format,
         }
+        if tool_id is not None:
+            payload["tool_id"] = tool_id
+        if tool_uuid is not None:
+            payload["tool_uuid"] = tool_uuid
+        if tool_version is not None:
+            payload["tool_version"] = tool_version
 
         if isinstance(tool_inputs, InputsBuilder):
             payload["inputs"] = tool_inputs.to_dict()

--- a/bioblend/galaxy/unprivileged_tools/__init__.py
+++ b/bioblend/galaxy/unprivileged_tools/__init__.py
@@ -88,8 +88,8 @@ class UnprivilegedToolsClient(Client):
         """
         Run an unprivileged tool by its ``tool_uuid``.
 
-        Unprivileged tool runs are submitted to the jobs API rather than the
-        regular tools API; the returned shape mirrors
+        Submitted to ``POST /api/tools``, which accepts ``tool_uuid`` as an
+        alternative to ``tool_id``; the returned shape mirrors
         :meth:`bioblend.galaxy.tools.ToolClient.run_tool`.
 
         :type history_id: str
@@ -128,5 +128,5 @@ class UnprivilegedToolsClient(Client):
         if tool_version is not None:
             payload["tool_version"] = tool_version
 
-        url = "/".join((self.gi.url, "jobs"))
+        url = "/".join((self.gi.url, "tools"))
         return self._post(payload, url=url)

--- a/bioblend/galaxy/unprivileged_tools/__init__.py
+++ b/bioblend/galaxy/unprivileged_tools/__init__.py
@@ -2,18 +2,16 @@
 Contains possible interactions with the Galaxy Unprivileged Tools API.
 
 Unprivileged tools let non-admin users register, list, fetch, and deactivate
-their own tool definitions, then run them via the jobs API using the tool's
-UUID.
+their own tool definitions. To run one, use
+:meth:`bioblend.galaxy.tools.ToolClient.run_tool` with ``tool_uuid``.
 """
 
 from typing import (
     Any,
-    Literal,
     TYPE_CHECKING,
 )
 
 from bioblend.galaxy.client import Client
-from bioblend.galaxy.tools.inputs import InputsBuilder
 
 if TYPE_CHECKING:
     from bioblend.galaxy import GalaxyInstance
@@ -76,57 +74,3 @@ class UnprivilegedToolsClient(Client):
         :param uuid: UUID of the unprivileged tool to deactivate.
         """
         self._delete(id=uuid)
-
-    def run_user_tool(
-        self,
-        history_id: str,
-        tool_uuid: str,
-        tool_inputs: InputsBuilder | dict[str, Any],
-        tool_version: str | None = None,
-        input_format: Literal["21.01", "legacy"] = "legacy",
-    ) -> dict[str, Any]:
-        """
-        Run an unprivileged tool by its ``tool_uuid``.
-
-        Submitted to ``POST /api/tools``, which accepts ``tool_uuid`` as an
-        alternative to ``tool_id``; the returned shape mirrors
-        :meth:`bioblend.galaxy.tools.ToolClient.run_tool`.
-
-        :type history_id: str
-        :param history_id: encoded ID of the history in which to run the tool
-
-        :type tool_uuid: str
-        :param tool_uuid: UUID of the unprivileged tool to be run
-
-        :type tool_inputs: dict
-        :param tool_inputs: dictionary of input datasets and parameters
-          for the tool (see :meth:`ToolClient.run_tool` for the expected
-          format)
-
-        :type tool_version: str
-        :param tool_version: Optional version of the unprivileged tool to run.
-
-        :type input_format: str
-        :param input_format: input format for the payload. Possible values are
-          the default ``'legacy'`` or ``'21.01'`` (see
-          :meth:`ToolClient.run_tool` for details).
-
-        :rtype: dict
-        :return: Information about outputs and the submitted job.
-        """
-        payload: dict[str, Any] = {
-            "history_id": history_id,
-            "tool_uuid": tool_uuid,
-            "input_format": input_format,
-        }
-
-        if isinstance(tool_inputs, InputsBuilder):
-            payload["inputs"] = tool_inputs.to_dict()
-        else:
-            payload["inputs"] = tool_inputs
-
-        if tool_version is not None:
-            payload["tool_version"] = tool_version
-
-        url = "/".join((self.gi.url, "tools"))
-        return self._post(payload, url=url)

--- a/bioblend/galaxy/unprivileged_tools/__init__.py
+++ b/bioblend/galaxy/unprivileged_tools/__init__.py
@@ -1,0 +1,132 @@
+"""
+Contains possible interactions with the Galaxy Unprivileged Tools API.
+
+Unprivileged tools let non-admin users register, list, fetch, and deactivate
+their own tool definitions, then run them via the jobs API using the tool's
+UUID.
+"""
+
+from typing import (
+    Any,
+    Literal,
+    TYPE_CHECKING,
+)
+
+from bioblend.galaxy.client import Client
+from bioblend.galaxy.tools.inputs import InputsBuilder
+
+if TYPE_CHECKING:
+    from bioblend.galaxy import GalaxyInstance
+
+
+class UnprivilegedToolsClient(Client):
+    gi: "GalaxyInstance"
+    module = "unprivileged_tools"
+
+    def __init__(self, galaxy_instance: "GalaxyInstance") -> None:
+        super().__init__(galaxy_instance)
+
+    def get_user_tools(self, active: bool = True) -> list[dict[str, Any]]:
+        """
+        List the current user's unprivileged tools.
+
+        :type active: bool
+        :param active: If ``True`` (the default), return only active tools;
+          if ``False``, return only deactivated tools.
+
+        :rtype: list
+        :return: A list of dicts describing the user's unprivileged tools.
+        """
+        return self._get(params={"active": active})
+
+    def show_user_tool(self, uuid: str) -> dict[str, Any]:
+        """
+        Show information on a single unprivileged tool.
+
+        :type uuid: str
+        :param uuid: UUID of the unprivileged tool to fetch.
+
+        :rtype: dict
+        :return: Details of the given unprivileged tool.
+        """
+        return self._get(id=uuid)
+
+    def create_user_tool(self, representation: dict[str, Any]) -> dict[str, Any]:
+        """
+        Register a new unprivileged tool from a tool ``representation``.
+
+        :type representation: dict
+        :param representation: The tool representation (the same structure
+          accepted by Galaxy's unprivileged tools API). It will be wrapped
+          as ``{"src": "representation", "representation": representation}``
+          before being POSTed.
+
+        :rtype: dict
+        :return: Details of the newly created unprivileged tool, including
+          its ``uuid``.
+        """
+        payload = {"src": "representation", "representation": representation}
+        return self._post(payload)
+
+    def delete_user_tool(self, uuid: str) -> None:
+        """
+        Deactivate an unprivileged tool.
+
+        :type uuid: str
+        :param uuid: UUID of the unprivileged tool to deactivate.
+        """
+        self._delete(id=uuid)
+
+    def run_user_tool(
+        self,
+        history_id: str,
+        tool_uuid: str,
+        tool_inputs: InputsBuilder | dict[str, Any],
+        tool_version: str | None = None,
+        input_format: Literal["21.01", "legacy"] = "legacy",
+    ) -> dict[str, Any]:
+        """
+        Run an unprivileged tool by its ``tool_uuid``.
+
+        Unprivileged tool runs are submitted to the jobs API rather than the
+        regular tools API; the returned shape mirrors
+        :meth:`bioblend.galaxy.tools.ToolClient.run_tool`.
+
+        :type history_id: str
+        :param history_id: encoded ID of the history in which to run the tool
+
+        :type tool_uuid: str
+        :param tool_uuid: UUID of the unprivileged tool to be run
+
+        :type tool_inputs: dict
+        :param tool_inputs: dictionary of input datasets and parameters
+          for the tool (see :meth:`ToolClient.run_tool` for the expected
+          format)
+
+        :type tool_version: str
+        :param tool_version: Optional version of the unprivileged tool to run.
+
+        :type input_format: str
+        :param input_format: input format for the payload. Possible values are
+          the default ``'legacy'`` or ``'21.01'`` (see
+          :meth:`ToolClient.run_tool` for details).
+
+        :rtype: dict
+        :return: Information about outputs and the submitted job.
+        """
+        payload: dict[str, Any] = {
+            "history_id": history_id,
+            "tool_uuid": tool_uuid,
+            "input_format": input_format,
+        }
+
+        if isinstance(tool_inputs, InputsBuilder):
+            payload["inputs"] = tool_inputs.to_dict()
+        else:
+            payload["inputs"] = tool_inputs
+
+        if tool_version is not None:
+            payload["tool_version"] = tool_version
+
+        url = "/".join((self.gi.url, "jobs"))
+        return self._post(payload, url=url)

--- a/bioblend/galaxy/unprivileged_tools/__init__.py
+++ b/bioblend/galaxy/unprivileged_tools/__init__.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 
 
 class UnprivilegedToolsClient(Client):
-    gi: "GalaxyInstance"
     module = "unprivileged_tools"
 
     def __init__(self, galaxy_instance: "GalaxyInstance") -> None:

--- a/docs/api_docs/galaxy/all.rst
+++ b/docs/api_docs/galaxy/all.rst
@@ -144,6 +144,13 @@ ToolShed
 
 -----
 
+Unprivileged tools
+------------------
+
+.. automodule:: bioblend.galaxy.unprivileged_tools
+
+-----
+
 Users
 -----
 


### PR DESCRIPTION
## Summary

- New ``UnprivilegedToolsClient`` wrapping ``/api/unprivileged_tools`` (create/list/show/deactivate) so callers like galaxy-mcp can stop hand-rolling URLs and JSON extraction.
- ``ToolClient.run_tool`` now accepts ``tool_uuid`` and ``tool_version`` kwargs so unprivileged user tools can be run by UUID -- both ``tool_id`` and ``tool_uuid`` go through ``POST /api/tools`` in Galaxy.
- Exactly one of ``tool_id`` or ``tool_uuid`` must be provided; existing positional callers are unaffected.

## Test plan

- [x] ``tox -e lint`` (ruff, flake8, black, isort, mypy) clean
- [ ] ``pytest tests/TestGalaxyUnprivilegedTools.py`` against a Galaxy with unprivileged_tools enabled and the user granted ``USER_TOOL_EXECUTE``
- [ ] Confirm existing ``TestGalaxyTools.py`` still passes (no regression in ``run_tool``)