### PR TITLE
Add first-class user-defined tool support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## BioBlend v1.10.0 - unreleased
+
+* Added first-class user-defined tool lifecycle and execution methods to
+  ``ToolClient``.
+
 ## BioBlend v1.9.0 - 2026-04-14
 
 * Added ``create_credentials()``, ``get_credentials()``,

--- a/bioblend/_tests/TestGalaxyUserTools.py
+++ b/bioblend/_tests/TestGalaxyUserTools.py
@@ -1,0 +1,184 @@
+import json
+from typing import (
+    Any,
+    cast,
+)
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from bioblend import ConnectionError
+from bioblend.galaxy import GalaxyInstance
+
+TOOL_UUID = "c9d94e82-4dc3-4d9a-a01f-1b60bb98dc80"
+REPRESENTATION = {
+    "class": "GalaxyUserTool",
+    "id": "copy-file",
+    "version": "1.0.0",
+    "name": "Copy a file",
+    "shell_command": "cp input output",
+    "container": "quay.io/biocontainers/coreutils:9.5--h4bc722e_0",
+}
+
+
+def response(payload: Any, status_code: int = 200) -> requests.Response:
+    result = requests.Response()
+    result.status_code = status_code
+    result._content = json.dumps(payload).encode()
+    result.encoding = "utf-8"
+    return result
+
+
+class TestGalaxyUserTools:
+    def setup_method(self):
+        self.gi = GalaxyInstance("http://localhost:56789", key="secret-api-key")
+
+    def test_methods_are_available(self):
+        for method in (
+            "get_user_tools",
+            "show_user_tool",
+            "create_user_tool",
+            "delete_user_tool",
+            "run_user_tool",
+        ):
+            assert callable(getattr(self.gi.tools, method))
+
+    def test_get_user_tools_passes_exact_active_query_parameter(self):
+        with patch("requests.get", return_value=response([])) as get:
+            assert self.gi.tools.get_user_tools(active=False) == []
+
+        assert get.call_args.args[0] == "http://localhost:56789/api/unprivileged_tools"
+        assert get.call_args.kwargs["params"] == {"active": False}
+
+    def test_show_user_tool_uses_uuid_url(self):
+        user_tool = {"uuid": TOOL_UUID}
+        with patch("requests.get", return_value=response(user_tool)) as get:
+            assert self.gi.tools.show_user_tool(TOOL_UUID) == user_tool
+
+        assert get.call_args.args[0] == f"http://localhost:56789/api/unprivileged_tools/{TOOL_UUID}"
+
+    def test_create_user_tool_wraps_inner_representation_once(self):
+        created = {"uuid": TOOL_UUID, "representation": REPRESENTATION}
+        with patch("requests.post", return_value=response(created)) as post:
+            assert self.gi.tools.create_user_tool(REPRESENTATION) == created
+
+        assert post.call_args.args[0] == "http://localhost:56789/api/unprivileged_tools"
+        assert json.loads(post.call_args.kwargs["data"]) == {
+            "src": "representation",
+            "representation": REPRESENTATION,
+        }
+
+    def test_create_user_tool_validates_representation(self):
+        with pytest.raises(TypeError, match="representation must be a dict"):
+            self.gi.tools.create_user_tool(cast(Any, []))
+
+        for field in REPRESENTATION:
+            incomplete = REPRESENTATION.copy()
+            del incomplete[field]
+            with pytest.raises(ValueError, match=field):
+                self.gi.tools.create_user_tool(incomplete)
+
+        wrong_class = {**REPRESENTATION, "class": "GalaxyTool"}
+        with pytest.raises(ValueError, match="GalaxyUserTool"):
+            self.gi.tools.create_user_tool(wrong_class)
+
+        wrong_container = {**REPRESENTATION, "container": {"type": "docker"}}
+        with pytest.raises(TypeError, match="container must be a string"):
+            self.gi.tools.create_user_tool(wrong_container)
+
+    def test_delete_user_tool_follows_delete_conventions(self):
+        with patch("requests.delete", return_value=response(None)) as delete:
+            assert self.gi.tools.delete_user_tool(TOOL_UUID) is None
+
+        assert delete.call_args.args[0] == f"http://localhost:56789/api/unprivileged_tools/{TOOL_UUID}"
+
+    def test_run_user_tool_looks_up_uuid_then_posts_exact_tools_payload(self):
+        calls: list[tuple[str, str]] = []
+        user_tool = {
+            "uuid": TOOL_UUID,
+            "active": True,
+            "tool_id": "copy-file",
+            "representation": {"version": "1.0.0"},
+        }
+        result = {"jobs": [{"id": "job-id"}], "outputs": [], "output_collections": []}
+        inputs = {
+            "dataset": {"src": "hda", "id": "dataset-id"},
+            "collection": {"src": "hdca", "id": "collection-id"},
+            "count": 3,
+        }
+
+        def get_response(url: str, **kwargs: Any) -> requests.Response:
+            calls.append(("GET", url))
+            return response(user_tool)
+
+        def post_response(url: str, **kwargs: Any) -> requests.Response:
+            calls.append(("POST", url))
+            return response(result)
+
+        with patch("requests.get", side_effect=get_response), patch("requests.post", side_effect=post_response) as post:
+            assert self.gi.tools.run_user_tool("history-id", TOOL_UUID, inputs) == result
+
+        assert calls == [
+            ("GET", f"http://localhost:56789/api/unprivileged_tools/{TOOL_UUID}"),
+            ("POST", "http://localhost:56789/api/tools"),
+        ]
+        assert json.loads(post.call_args.kwargs["data"]) == {
+            "history_id": "history-id",
+            "tool_uuid": TOOL_UUID,
+            "tool_version": "1.0.0",
+            "inputs": inputs,
+            "input_format": "legacy",
+        }
+        assert "tool_id" not in json.loads(post.call_args.kwargs["data"])
+        assert all("/api/jobs" not in url for _, url in calls)
+
+    def test_empty_identifiers_and_non_dict_inputs_are_rejected(self):
+        with pytest.raises(ValueError, match="tool_uuid"):
+            self.gi.tools.show_user_tool("")
+        with pytest.raises(ValueError, match="tool_uuid"):
+            self.gi.tools.delete_user_tool("")
+        with pytest.raises(ValueError, match="history_id"):
+            self.gi.tools.run_user_tool("", TOOL_UUID, {})
+        with pytest.raises(ValueError, match="tool_uuid"):
+            self.gi.tools.run_user_tool("history-id", "", {})
+        with pytest.raises(TypeError, match="inputs must be a dict"):
+            self.gi.tools.run_user_tool("history-id", TOOL_UUID, cast(Any, []))
+
+    @pytest.mark.parametrize(
+        ("user_tool", "message"),
+        [
+            (None, "returned no user-defined tool"),
+            ({"active": False, "representation": {"version": "1.0.0"}}, "is inactive"),
+            ({"active": True, "representation": {}}, "has no representation version"),
+            ({"active": True}, "has no representation version"),
+        ],
+    )
+    def test_run_user_tool_rejects_unusable_lookup_responses(self, user_tool, message):
+        with patch("requests.get", return_value=response(user_tool)), pytest.raises(ValueError, match=message):
+            self.gi.tools.run_user_tool("history-id", TOOL_UUID, {})
+
+    def test_galaxy_http_error_preserves_status_and_body_without_credentials(self):
+        error_body = {"err_msg": "User-defined tool was not found"}
+        with patch("requests.get", return_value=response(error_body, 404)), pytest.raises(ConnectionError) as exc:
+            self.gi.tools.run_user_tool("history-id", TOOL_UUID, {})
+
+        assert exc.value.status_code == 404
+        assert isinstance(exc.value.body, (bytes, str))
+        assert json.loads(exc.value.body) == error_body
+        assert "secret-api-key" not in str(exc.value)
+
+    def test_run_submission_error_preserves_status_and_body_without_credentials(self):
+        user_tool = {"active": True, "representation": {"version": "1.0.0"}}
+        error_body = {"err_msg": "Invalid tool inputs"}
+        with (
+            patch("requests.get", return_value=response(user_tool)),
+            patch("requests.post", return_value=response(error_body, 400)),
+            pytest.raises(ConnectionError) as exc,
+        ):
+            self.gi.tools.run_user_tool("history-id", TOOL_UUID, {})
+
+        assert exc.value.status_code == 400
+        assert isinstance(exc.value.body, (bytes, str))
+        assert json.loads(exc.value.body) == error_body
+        assert "secret-api-key" not in str(exc.value)

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -459,6 +459,68 @@ class ToolClient(Client):
         url = f"{self.gi.url}/unprivileged_tools/{tool_uuid}"
         return self._delete(url=url)
 
+    def run_user_tool(
+        self,
+        history_id: str,
+        tool_uuid: str,
+        inputs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Run a user-defined tool in a history.
+
+        The lifecycle lookup uses Galaxy's ``/api/unprivileged_tools`` API,
+        while execution uses ``/api/tools`` with the UUID and resolved tool
+        version. Dataset, collection, and scalar input references are passed
+        through unchanged. ``/api/jobs`` is not a portable submission route
+        for user-defined tools.
+
+        Wait for submitted jobs with, for example::
+
+            result = gi.tools.run_user_tool(history_id, tool_uuid, inputs)
+            for job in result.get("jobs", []):
+                gi.jobs.wait_for_job(job["id"])
+
+        :type history_id: str
+        :param history_id: encoded ID of the history in which to run the tool
+
+        :type tool_uuid: str
+        :param tool_uuid: UUID of the user-defined tool, not an ordinary tool ID
+
+        :type inputs: dict
+        :param inputs: user-defined tool inputs
+
+        :rtype: dict
+        :return: Information about jobs, outputs, and output collections.
+        """
+        if not history_id:
+            raise ValueError("history_id must not be empty")
+        if not tool_uuid:
+            raise ValueError("tool_uuid must not be empty")
+        if not isinstance(inputs, dict):
+            raise TypeError("inputs must be a dict")
+
+        user_tool = self.show_user_tool(tool_uuid)
+        if not isinstance(user_tool, dict) or not user_tool:
+            raise ValueError(f"Galaxy returned no user-defined tool for UUID {tool_uuid!r}")
+
+        tool_id = user_tool.get("tool_id")
+        diagnostic = f"UUID {tool_uuid!r}" + (f" (tool_id {tool_id!r})" if tool_id else "")
+        if user_tool.get("active") is False:
+            raise ValueError(f"User-defined tool {diagnostic} is inactive")
+
+        representation = user_tool.get("representation")
+        tool_version = representation.get("version") if isinstance(representation, dict) else None
+        if not tool_version:
+            raise ValueError(f"User-defined tool {diagnostic} has no representation version")
+
+        payload = {
+            "history_id": history_id,
+            "tool_uuid": tool_uuid,
+            "tool_version": tool_version,
+            "inputs": inputs,
+            "input_format": "legacy",
+        }
+        return self._post(payload=payload)
+
     def run_tool(
         self,
         history_id: str,

--- a/bioblend/galaxy/tools/__init__.py
+++ b/bioblend/galaxy/tools/__init__.py
@@ -376,6 +376,89 @@ class ToolClient(Client):
 
         return self._post(payload=params, url=url)
 
+    def get_user_tools(self, active: bool = True) -> list[dict[str, Any]]:
+        """Get the current user's user-defined tools.
+
+        Galaxy calls the underlying API "unprivileged tools". The ``active``
+        argument must match both Galaxy's dynamic-tool state and the current
+        user's association state. Since deletion normally deactivates only the
+        association, a deleted tool may appear in neither result set.
+
+        :type active: bool
+        :param active: active state to select
+
+        :rtype: list
+        :return: List of user-defined tool descriptions.
+        """
+        url = f"{self.gi.url}/unprivileged_tools"
+        return self._get(url=url, params={"active": active})
+
+    def show_user_tool(self, tool_uuid: str) -> dict[str, Any]:
+        """Get a user-defined tool by UUID.
+
+        Galaxy calls the underlying API "unprivileged tools". ``tool_uuid``
+        is the user-defined tool UUID, not an encoded Galaxy ID or ordinary
+        tool ID.
+
+        :type tool_uuid: str
+        :param tool_uuid: UUID of the user-defined tool
+
+        :rtype: dict
+        :return: Description of the user-defined tool.
+        """
+        if not tool_uuid:
+            raise ValueError("tool_uuid must not be empty")
+        url = f"{self.gi.url}/unprivileged_tools/{tool_uuid}"
+        return self._get(url=url)
+
+    def create_user_tool(self, representation: dict[str, Any]) -> dict[str, Any]:
+        """Create a user-defined tool from a GalaxyUserTool representation.
+
+        Galaxy calls the underlying API "unprivileged tools". This method
+        accepts the inner representation and adds Galaxy's request envelope.
+        Galaxy remains authoritative for the complete representation schema.
+
+        :type representation: dict
+        :param representation: GalaxyUserTool representation
+
+        :rtype: dict
+        :return: Description of the created user-defined tool, including its UUID.
+        """
+        if not isinstance(representation, dict):
+            raise TypeError("representation must be a dict")
+        required_fields = ("class", "id", "version", "name", "shell_command", "container")
+        missing_fields = [field for field in required_fields if field not in representation]
+        if missing_fields:
+            raise ValueError(
+                f"User-defined tool representation is missing required fields: {', '.join(missing_fields)}"
+            )
+        if representation["class"] != "GalaxyUserTool":
+            raise ValueError("representation class must be 'GalaxyUserTool'")
+        if not isinstance(representation["container"], str):
+            raise TypeError("representation container must be a string")
+
+        url = f"{self.gi.url}/unprivileged_tools"
+        payload = {"src": "representation", "representation": representation}
+        return self._post(payload=payload, url=url)
+
+    def delete_user_tool(self, tool_uuid: str) -> Any:
+        """Deactivate a user-defined tool by UUID.
+
+        Galaxy calls the underlying API "unprivileged tools" and normally
+        deactivates rather than removes the tool. The return value follows
+        BioBlend's standard DELETE conventions.
+
+        :type tool_uuid: str
+        :param tool_uuid: UUID of the user-defined tool
+
+        :return: Galaxy's decoded response, or ``None`` according to BioBlend's
+          standard DELETE conventions.
+        """
+        if not tool_uuid:
+            raise ValueError("tool_uuid must not be empty")
+        url = f"{self.gi.url}/unprivileged_tools/{tool_uuid}"
+        return self._delete(url=url)
+
     def run_tool(
         self,
         history_id: str,

--- a/docs/api_docs/galaxy/docs.rst
+++ b/docs/api_docs/galaxy/docs.rst
@@ -175,6 +175,40 @@ If files are greater than 2GB in size, they will need to be uploaded via FTP. Im
                   'uuid': '2cbe8f0a-4019-47c4-87e2-005ce35b8449',
                   'visible': True}]}
 
+Create and run a user-defined tool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Galaxy calls the lifecycle API for user-defined tools "unprivileged tools". These operations use ``/api/unprivileged_tools`` and identify a tool by its UUID, which is distinct from a normal ``tool_id``. Execution uses ``/api/tools`` with that UUID; submitting a user-defined tool through ``/api/jobs`` is not portable.
+
+This API requires Galaxy 25.0 or later. The Galaxy administrator must enable beta tool formats and grant the account permission to execute user-defined tools.
+
+The following example creates a tool, runs it with a native Galaxy dataset reference, waits for its jobs, collects output IDs, and deactivates it::
+
+    representation = {
+        "class": "GalaxyUserTool",
+        "id": "copy-file",
+        "version": "1.0.0",
+        "name": "Copy a file",
+        "container": "quay.io/biocontainers/coreutils:9.5--h4bc722e_0",
+        "shell_command": "cp '$(inputs.input_file.path)' output.txt",
+        "inputs": [{"name": "input_file", "type": "data"}],
+        "outputs": [{"name": "output", "type": "data", "format": "txt", "from_work_dir": "output.txt"}],
+    }
+
+    created = gi.tools.create_user_tool(representation)
+    tool_uuid = created["uuid"]
+    result = gi.tools.run_user_tool(
+        history_id,
+        tool_uuid,
+        {"input_file": {"src": "hda", "id": dataset_id}},
+    )
+    for job in result.get("jobs", []):
+        gi.jobs.wait_for_job(job["id"])
+    output_ids = [output["id"] for output in result.get("outputs", [])]
+    gi.tools.delete_user_tool(tool_uuid)
+
+``delete_user_tool()`` normally deactivates only the current user's association with the tool. Galaxy applies the ``active`` filter to both that association and the underlying dynamic-tool record, so a normally deleted tool may appear in neither ``get_user_tools(active=True)`` nor ``get_user_tools(active=False)``. Higher-level applications can compose create, run, and wait operations when needed.
+
 
 View Data Libraries
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Overview

Add first-class Galaxy user-defined tool support to `ToolClient` using Galaxy's `/api/unprivileged_tools` lifecycle endpoints and `/api/tools` execution endpoint.

## Changes

- add list, show, create, and delete methods for user-defined tools
- add `run_user_tool()` with UUID lookup and version resolution
- validate required representation fields and execution inputs
- preserve native dataset, collection, and scalar input references
- document create, run, wait, output, and cleanup usage
- add request-level tests for payloads, errors, and credential safety

## Validation

- 14 focused UDT tests passed
- full local suite: 26 passed, 255 live-Galaxy tests skipped
- Ruff, Flake8, Black, isort, mypy, and ty passed
- Sphinx HTML build passed
- live usegalaxy.org 26.1 lifecycle passed: create, show, list, run, wait, output verification, deactivate, and history cleanup

## Compatibility

Requires Galaxy 25.0 or later with beta tool formats enabled and user-defined tool execution permission.
