### PR TITLE
Retry requests rejected with HTTP status 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@
   must be provided (thanks to
   [Dannon Baker](https://github.com/dannon)).
 
+* Requests rejected with HTTP status 429 (Too Many Requests) are now retried
+  automatically, honouring the ``Retry-After`` header. All HTTP methods are
+  retried, since a 429 response means that the request was rejected before being
+  processed. Multipart uploads are not retried, because their body cannot be
+  replayed.
+
+* Added ``max_total_retry_delay``, ``max_retry_after`` and ``max_429_retries``
+  properties to ``GalaxyClient``, bounding the above. Retrying stops after a
+  total of 60 s of waiting by default; set ``max_total_retry_delay`` to 0 to
+  disable it.
+
+* Added ``use_session`` property, ``close()`` method and context manager support
+  to ``GalaxyClient``, to reuse connections across requests. Disabled by
+  default.
+
+* ``Client._get()`` does not retry requests rejected with HTTP status 429 any
+  more, as they have already been retried. This only affects users who set
+  ``max_get_attempts`` to a value greater than 1.
+
+* Added dependency on ``urllib3`` >= 2.0, previously an indirect one through
+  ``requests``.
+
 ## BioBlend v1.9.0 - 2026-04-14
 
 * Added ``create_credentials()``, ``get_credentials()``,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@
   must be provided (thanks to
   [Dannon Baker](https://github.com/dannon)).
 
+* Requests rejected with HTTP status 429 (Too Many Requests) are now retried
+  automatically, honouring the ``Retry-After`` header. All HTTP methods are
+  retried, since a 429 response means that the request was rejected before being
+  processed. Multipart uploads are not retried, because their body cannot be
+  replayed.
+
+* Added ``max_total_retry_delay``, ``max_retry_after`` and ``max_429_retries``
+  properties to ``GalaxyClient``, bounding the above. Retrying stops after a
+  total of 60 s of waiting by default; set ``max_total_retry_delay`` to 0 to
+  disable it.
+
+* Added ``use_session`` property, ``close()`` method and context manager support
+  to ``GalaxyClient``, to reuse connections across requests. Disabled by
+  default.
+
+* ``Client._get()`` does not retry requests rejected with HTTP status 429 any
+  more, as they have already been retried. This only affects users who set
+  ``max_get_attempts`` to a value greater than 1.
+
+* Added dependency on ``urllib3`` >= 2.0, previously an indirect one through
+  ``requests``.
+
 ## BioBlend v1.9.0 - 2026-04-14
 
 * Added ``create_credentials()``, ``get_credentials()``,

--- a/bioblend/_tests/TestGalaxyRateLimit.py
+++ b/bioblend/_tests/TestGalaxyRateLimit.py
@@ -17,6 +17,7 @@ from http.server import (
 from typing import Any
 
 import pytest
+from typing_extensions import Self
 
 from bioblend import ConnectionError
 from bioblend.galaxy import GalaxyInstance
@@ -72,7 +73,7 @@ class MockServer:
     def request_count(self) -> int:
         return len(self.requests)
 
-    def __enter__(self) -> "MockServer":
+    def __enter__(self) -> Self:
         self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
         self._thread.start()
         return self
@@ -237,7 +238,10 @@ class TestGalaxySession(unittest.TestCase):
             with gi as entered:
                 assert entered is gi
                 used_inside = gi.use_session
-                assert gi.make_get_request(f"{gi.url}/libraries").status_code == 200
+                # Accessing a GalaxyInstance-only attribute also checks that
+                # entering the context manager preserves the subclass.
+                assert entered.libraries.gi is entered
+                assert entered.make_get_request(f"{gi.url}/libraries").status_code == 200
             assert used_inside is True
             assert gi.use_session is False
 

--- a/bioblend/_tests/TestGalaxyRateLimit.py
+++ b/bioblend/_tests/TestGalaxyRateLimit.py
@@ -1,0 +1,276 @@
+"""
+Tests on the handling of HTTP status 429 (Too Many Requests) responses.
+
+These tests do not need a Galaxy instance: they run against a minimal HTTP
+server replying with a canned sequence of status codes. A real server is needed
+because the retrying happens inside urllib3, below the layer at which HTTP
+mocking libraries usually work.
+"""
+
+import threading
+import time
+import unittest
+from http.server import (
+    BaseHTTPRequestHandler,
+    ThreadingHTTPServer,
+)
+from typing import Any
+
+import pytest
+
+from bioblend import ConnectionError
+from bioblend.galaxy import GalaxyInstance
+
+
+class MockServer:
+    """
+    HTTP server replying with a canned sequence of status codes.
+
+    The last status code of the sequence is repeated for any further request.
+    """
+
+    def __init__(self, statuses: list[int], retry_after: int | None = None) -> None:
+        self.statuses = statuses
+        self.retry_after = retry_after
+        self.requests: list[tuple[str, str]] = []
+        lock = threading.Lock()
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def _reply(self) -> None:
+                # The request body must be consumed, otherwise the client may
+                # block while writing it.
+                content_length = int(self.headers.get("Content-Length") or 0)
+                if content_length:
+                    self.rfile.read(content_length)
+                with lock:
+                    index = len(server.requests)
+                    server.requests.append((self.command, self.path))
+                status = server.statuses[min(index, len(server.statuses) - 1)]
+                body = b'{"ok": true}' if status == 200 else b'{"error": "nope"}'
+                self.send_response(status)
+                if status == 429 and server.retry_after is not None:
+                    self.send_header("Retry-After", str(server.retry_after))
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            do_GET = _reply
+            do_POST = _reply
+            do_PUT = _reply
+            do_PATCH = _reply
+            do_DELETE = _reply
+
+            def log_message(self, format: str, *args: Any) -> None:
+                pass
+
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self._httpd.server_address[1]}"
+
+    @property
+    def request_count(self) -> int:
+        return len(self.requests)
+
+    def __enter__(self) -> "MockServer":
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join()
+
+
+def galaxy_instance(server: MockServer, **kwargs: object) -> GalaxyInstance:
+    """
+    Return a ``GalaxyInstance`` pointing at ``server``, with retry delays short
+    enough to keep the tests fast.
+    """
+    gi = GalaxyInstance(server.url, key="whatever")
+    gi.max_retry_after = 0.1
+    gi.max_total_retry_delay = 1.0
+    for name, value in kwargs.items():
+        setattr(gi, name, value)
+    return gi
+
+
+class TestGalaxyRateLimit(unittest.TestCase):
+    def test_get_is_retried(self):
+        with MockServer([429, 429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server)
+            r = gi.make_get_request(f"{gi.url}/libraries")
+            assert r.status_code == 200
+            assert server.request_count == 3
+
+    def test_post_is_retried(self):
+        # A 429 response means the request was rejected before being processed,
+        # so even a non-idempotent method can safely be replayed.
+        with MockServer([429, 429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server)
+            assert gi.make_post_request(f"{gi.url}/histories", payload={"name": "test"}) == {"ok": True}
+            assert server.request_count == 3
+            assert [method for method, _ in server.requests] == ["POST"] * 3
+
+    def test_put_and_delete_are_retried(self):
+        with MockServer([429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server)
+            assert gi.make_put_request(f"{gi.url}/histories/abc", payload={"name": "test"}) == {"ok": True}
+            assert server.request_count == 2
+        with MockServer([429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server)
+            r = gi.make_delete_request(f"{gi.url}/histories/abc")
+            assert r.status_code == 200
+            assert server.request_count == 2
+
+    def test_multipart_post_is_not_retried(self):
+        # The body of a multipart request is a stream which is not rewound
+        # between attempts, so replaying it would send a truncated body.
+        with MockServer([429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server)
+            with pytest.raises(ConnectionError) as excinfo:
+                gi.make_post_request(f"{gi.url}/tools", payload={"name": "test"}, files_attached=True)
+            assert excinfo.value.status_code == 429
+            assert server.request_count == 1
+
+    def test_retries_exhausted_raises_connection_error(self):
+        with MockServer([429], retry_after=1) as server:
+            gi = galaxy_instance(server)
+            with pytest.raises(ConnectionError) as excinfo:
+                gi.make_post_request(f"{gi.url}/histories", payload={})
+            assert excinfo.value.status_code == 429
+            assert excinfo.value.body == '{"error": "nope"}'
+            assert server.request_count > 1
+
+    def test_max_total_retry_delay_caps_the_wait(self):
+        # The server asks to wait much longer than the budget allows.
+        with MockServer([429], retry_after=3600) as server:
+            gi = galaxy_instance(server, max_retry_after=0.2, max_total_retry_delay=0.5)
+            start = time.monotonic()
+            assert gi.make_get_request(f"{gi.url}/libraries").status_code == 429
+            duration = time.monotonic() - start
+            # Worst case is max_total_retry_delay + max_retry_after, plus the
+            # time spent on the requests themselves.
+            assert duration < 3, f"Retrying took {duration} s, ignoring the delay budget"
+
+    def test_max_total_retry_delay_of_zero_disables_retrying(self):
+        with MockServer([429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server, max_total_retry_delay=0)
+            assert gi.make_get_request(f"{gi.url}/libraries").status_code == 429
+            assert server.request_count == 1
+
+    def test_max_429_retries_limits_retrying_without_delays(self):
+        # With no delay between attempts the budget is never consumed, so the
+        # number of retries is what stops the loop.
+        with MockServer([429], retry_after=0) as server:
+            gi = galaxy_instance(server, max_retry_after=0, max_total_retry_delay=60, max_429_retries=3)
+            assert gi.make_get_request(f"{gi.url}/libraries").status_code == 429
+            assert server.request_count == 4
+
+    def test_other_error_statuses_are_not_retried(self):
+        with MockServer([500]) as server:
+            gi = galaxy_instance(server)
+            with pytest.raises(ConnectionError) as excinfo:
+                gi.make_post_request(f"{gi.url}/histories", payload={})
+            assert excinfo.value.status_code == 500
+            assert server.request_count == 1
+
+    def test_get_client_does_not_retry_429_again(self):
+        # `_get()` retries failed GET requests, but a 429 response has already
+        # been retried by the session, so it must not be tried again.
+        with MockServer([429], retry_after=0) as server:
+            gi = galaxy_instance(
+                server,
+                max_retry_after=0,
+                max_429_retries=0,
+                max_get_attempts=3,
+                get_retry_delay=30,
+            )
+            start = time.monotonic()
+            with pytest.raises(ConnectionError) as excinfo:
+                gi.libraries.get_libraries()
+            duration = time.monotonic() - start
+            assert excinfo.value.status_code == 429
+            assert server.request_count == 1
+            assert duration < 5, f"Took {duration} s, the GET retry loop was not skipped"
+
+    def test_get_client_still_retries_other_errors(self):
+        with MockServer([500, 500, 200]) as server:
+            gi = galaxy_instance(server, max_get_attempts=3, get_retry_delay=0)
+            libraries: Any = gi.libraries.get_libraries()
+            assert libraries == {"ok": True}
+            assert server.request_count == 3
+
+    def test_streamed_response_is_readable(self):
+        with MockServer([429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server)
+            r = gi.make_get_request(f"{gi.url}/datasets/abc/display", stream=True)
+            assert r.status_code == 200
+            assert b"".join(r.iter_content(4)) == b'{"ok": true}'
+
+
+class TestGalaxySession(unittest.TestCase):
+    def test_session_is_not_used_by_default(self):
+        with MockServer([200]) as server:
+            gi = galaxy_instance(server)
+            assert gi.use_session is False
+            assert gi.make_get_request(f"{gi.url}/libraries").status_code == 200
+
+    def test_session_is_used_and_retries_when_enabled(self):
+        with MockServer([429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server, use_session=True)
+            assert gi.use_session is True
+            assert gi.make_get_request(f"{gi.url}/libraries").status_code == 200
+            assert server.request_count == 2
+
+    def test_requests_keep_working_after_closing_the_session(self):
+        with MockServer([200]) as server:
+            gi = galaxy_instance(server, use_session=True)
+            gi.close()
+            assert gi.use_session is False
+            assert gi.make_get_request(f"{gi.url}/libraries").status_code == 200
+
+    def test_context_manager_enables_and_closes_the_session(self):
+        with MockServer([200]) as server:
+            gi = galaxy_instance(server)
+            with gi as entered:
+                assert entered is gi
+                used_inside = gi.use_session
+                assert gi.make_get_request(f"{gi.url}/libraries").status_code == 200
+            assert used_inside is True
+            assert gi.use_session is False
+
+    def test_changing_settings_keeps_the_session_usable(self):
+        with MockServer([429, 200], retry_after=1) as server:
+            gi = galaxy_instance(server, use_session=True)
+            gi.max_429_retries = 5
+            assert gi.use_session is True
+            assert gi.make_get_request(f"{gi.url}/libraries").status_code == 200
+
+
+class TestGalaxyRetrySettings(unittest.TestCase):
+    def setUp(self):
+        self.gi = GalaxyInstance("http://localhost:56789", key="whatever")
+
+    def test_defaults(self):
+        assert self.gi.max_429_retries == 10
+        assert self.gi.max_retry_after == 30.0
+        assert self.gi.max_total_retry_delay == 60.0
+        assert self.gi.use_session is False
+
+    def test_settings_can_be_changed(self):
+        self.gi.max_429_retries = 2
+        assert self.gi.max_429_retries == 2
+        self.gi.max_retry_after = 1.5
+        assert self.gi.max_retry_after == 1.5
+        self.gi.max_total_retry_delay = 5.0
+        assert self.gi.max_total_retry_delay == 5.0
+
+    def test_negative_settings_are_rejected(self):
+        with pytest.raises(ValueError):
+            self.gi.max_429_retries = -1
+        with pytest.raises(ValueError):
+            self.gi.max_retry_after = -1.0
+        with pytest.raises(ValueError):
+            self.gi.max_total_retry_delay = -1.0

--- a/bioblend/galaxy/client.py
+++ b/bioblend/galaxy/client.py
@@ -155,6 +155,12 @@ class Client:
                             msg = f"GET: invalid JSON : {r.content!r}"
                 else:
                     msg = f"GET: error {r.status_code}: {r.content!r}"
+                    if r.status_code == 429:
+                        # Rate-limited requests are already retried while
+                        # honouring the Retry-After header, see gi's
+                        # `max_total_retry_delay` property. Trying again here
+                        # would only add load to an overloaded server.
+                        attempts_left = 0
             msg = f"{msg}, {attempts_left} attempts left"
             if attempts_left <= 0:
                 bioblend.log.error(msg)

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -10,6 +10,9 @@ import base64
 import contextlib
 import json
 import logging
+import time
+from collections.abc import Iterator
+from types import TracebackType
 from typing import (
     Any,
 )
@@ -17,9 +20,13 @@ from typing import (
 import requests
 import tusclient.client
 import tusclient.exceptions
+from requests.adapters import HTTPAdapter
 from requests_toolbelt import MultipartEncoder
 from tusclient.storage.filestorage import FileStorage
 from tusclient.uploader.uploader import Uploader
+from urllib3 import BaseHTTPResponse
+from urllib3.connectionpool import ConnectionPool
+from urllib3.util.retry import Retry
 
 from bioblend import ConnectionError
 from bioblend.util import FileStream
@@ -27,6 +34,93 @@ from bioblend.util import FileStream
 log = logging.getLogger(__name__)
 
 UPLOAD_CHUNK_SIZE = 10**7
+
+# Default settings for retrying requests rejected with HTTP status 429 (Too
+# Many Requests). ``MAX_TOTAL_RETRY_DELAY`` is the limit which normally applies:
+# retrying stops once that much time has been spent waiting. ``MAX_429_RETRIES``
+# is a backstop for the case where the waits are all zero, e.g. when
+# ``max_retry_after`` is set to 0, since the delay budget is then never used up.
+DEFAULT_MAX_TOTAL_RETRY_DELAY = 60.0
+DEFAULT_MAX_RETRY_AFTER = 30.0
+DEFAULT_MAX_429_RETRIES = 10
+# Base of the exponential backoff used when a 429 response carries no
+# Retry-After header, and the random fraction added on top of it.
+RETRY_BACKOFF_FACTOR = 1.0
+RETRY_BACKOFF_JITTER = 0.5
+# Number of connections kept in the pool when ``use_session`` is enabled.
+SESSION_POOL_MAXSIZE = 20
+
+
+class _RateLimitRetry(Retry):
+    """
+    Retry policy for requests rejected with HTTP status 429 (Too Many Requests).
+
+    urllib3 already honours the ``Retry-After`` header, but puts no upper bound
+    on it, nor on the total time spent sleeping. This subclass adds both, so
+    that a rate-limited request fails within a predictable amount of time
+    instead of blocking for as long as the server asks for.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        max_retry_after: float = DEFAULT_MAX_RETRY_AFTER,
+        max_total_retry_delay: float = DEFAULT_MAX_TOTAL_RETRY_DELAY,
+        total_delay: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        self.max_retry_after = max_retry_after
+        self.max_total_retry_delay = max_total_retry_delay
+        self.total_delay = total_delay
+        super().__init__(*args, **kwargs)
+
+    def new(self, **kwargs: Any) -> "_RateLimitRetry":
+        # Retry objects are immutable: urllib3 builds a new one for each
+        # attempt, so the extra attributes must be carried over explicitly,
+        # otherwise both the cap and the accumulated delay would be lost after
+        # the first retry.
+        kwargs.setdefault("max_retry_after", self.max_retry_after)
+        kwargs.setdefault("max_total_retry_delay", self.max_total_retry_delay)
+        kwargs.setdefault("total_delay", self.total_delay)
+        return super().new(**kwargs)
+
+    def get_retry_after(self, response: BaseHTTPResponse) -> float | None:
+        retry_after = super().get_retry_after(response)
+        if retry_after is None:
+            return None
+        return min(retry_after, self.max_retry_after)
+
+    def sleep(self, response: BaseHTTPResponse | None = None) -> None:
+        start = time.monotonic()
+        super().sleep(response)
+        self.total_delay += time.monotonic() - start
+
+    def is_exhausted(self) -> bool:
+        return self.total_delay >= self.max_total_retry_delay or super().is_exhausted()
+
+    def increment(
+        self,
+        method: str | None = None,
+        url: str | None = None,
+        response: BaseHTTPResponse | None = None,
+        error: Exception | None = None,
+        _pool: ConnectionPool | None = None,
+        _stacktrace: TracebackType | None = None,
+    ) -> "_RateLimitRetry":
+        # Raises MaxRetryError when the budget or the backstop count is spent,
+        # in which case urllib3 returns the last response (raise_on_status is
+        # disabled) and BioBlend reports it as usual.
+        new_retry = super().increment(method, url, response, error, _pool, _stacktrace)
+        if response is not None:
+            log.warning(
+                "%s %s was rate-limited with HTTP status %s, retrying (%.1f of %.1f s of retry delay budget used)",
+                method,
+                url,
+                response.status,
+                self.total_delay,
+                self.max_total_retry_delay,
+            )
+        return new_retry
 
 
 class GalaxyClient:
@@ -50,14 +144,21 @@ class GalaxyClient:
         """
         self.verify = verify
         self.timeout = timeout
+        # Settings for retrying requests rejected with HTTP status 429, used to
+        # build the session, so they need to be set before any request is made.
+        self._max_429_retries = DEFAULT_MAX_429_RETRIES
+        self._max_retry_after = DEFAULT_MAX_RETRY_AFTER
+        self._max_total_retry_delay = DEFAULT_MAX_TOTAL_RETRY_DELAY
+        # Persistent session, only used when `use_session` is enabled.
+        self._session: requests.Session | None = None
         # Make sure the URL scheme is defined (otherwise requests will not work)
         if not url.lower().startswith("http"):
             found_scheme = None
             # Try to guess the scheme, starting from the more secure
             for scheme in ("https://", "http://"):
                 log.warning("Missing scheme in url, trying with %s", scheme)
-                with contextlib.suppress(requests.RequestException):
-                    r = requests.get(
+                with contextlib.suppress(requests.RequestException), self._session_ctx() as session:
+                    r = session.get(
                         scheme + url,
                         timeout=self.timeout,
                         verify=self.verify,
@@ -93,6 +194,168 @@ class GalaxyClient:
         self._max_get_attempts = 1
         # Delay in seconds between subsequent retries.
         self._get_retry_delay = 10.0
+
+    def _new_session(self) -> requests.Session:
+        """
+        Create a session which retries requests rejected with HTTP status 429.
+
+        Only 429 responses are retried: connection and read errors are re-raised
+        immediately, as they were before sessions were introduced.
+        """
+        retry = _RateLimitRetry(
+            # Only the status counter limits retrying, so that `total` does not
+            # allow connection and read errors to be retried too. Those are
+            # counted down to a negative value on their first occurrence, which
+            # makes urllib3 give up immediately and raise the same exceptions
+            # requests raises with its own default (non-retrying) adapter.
+            total=None,
+            status=self._max_429_retries,
+            connect=0,
+            read=False,
+            other=0,
+            status_forcelist=frozenset({429}),
+            # Retry all methods, including POST: a 429 response means that the
+            # request was rejected before being processed, so replaying it
+            # cannot duplicate any server-side action.
+            allowed_methods=None,
+            backoff_factor=RETRY_BACKOFF_FACTOR,
+            backoff_max=self._max_retry_after,
+            backoff_jitter=RETRY_BACKOFF_JITTER,
+            respect_retry_after_header=True,
+            # Return the last response instead of raising, so that the caller
+            # gets the usual ConnectionError with its body and status code.
+            raise_on_status=False,
+            max_retry_after=self._max_retry_after,
+            max_total_retry_delay=self._max_total_retry_delay,
+        )
+        adapter = HTTPAdapter(max_retries=retry, pool_maxsize=SESSION_POOL_MAXSIZE)
+        session = requests.Session()
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
+
+    @contextlib.contextmanager
+    def _session_ctx(self, retry: bool = True) -> Iterator[requests.Session]:
+        """
+        Yield the session to use for a single request.
+
+        Unless ``use_session`` is enabled, a new session is created for each
+        request and closed afterwards, which is what ``requests.get()`` and
+        friends do internally anyway.
+
+        Retrying must be disabled for requests whose body is a stream which
+        cannot be rewound, e.g. a multipart upload: neither urllib3 nor requests
+        rewind the body between attempts, so a replayed request would send a
+        truncated body and hang waiting on its own Content-Length.
+        """
+        if not retry:
+            with requests.Session() as session:
+                yield session
+        elif self._session is not None:
+            yield self._session
+        else:
+            session = self._new_session()
+            try:
+                yield session
+            finally:
+                session.close()
+
+    def _reset_session(self) -> None:
+        """
+        Rebuild the persistent session, if any, e.g. after a settings change.
+        """
+        if self._session is not None:
+            self._session.close()
+            self._session = self._new_session()
+
+    @property
+    def use_session(self) -> bool:
+        """
+        Whether a single session is reused for all requests. Default: ``False``
+
+        Enabling this reuses connections across requests, which is faster when
+        making many of them. The resulting object should not be shared between
+        threads, and ``close()`` should be called when done with it.
+        """
+        return self._session is not None
+
+    @use_session.setter
+    def use_session(self, value: bool) -> None:
+        if value:
+            if self._session is None:
+                self._session = self._new_session()
+        else:
+            self.close()
+
+    def close(self) -> None:
+        """
+        Close the persistent session, if any, releasing its connections.
+        """
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+
+    def __enter__(self) -> "GalaxyClient":
+        self.use_session = True
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    @property
+    def max_429_retries(self) -> int:
+        """
+        The maximum number of retries of a request rejected with HTTP status
+        429 (Too Many Requests). Default: 10
+
+        This is a backstop for the case where the waits between attempts are all
+        zero: the limit which normally applies is ``max_total_retry_delay``.
+        """
+        return self._max_429_retries
+
+    @max_429_retries.setter
+    def max_429_retries(self, value: int) -> None:
+        if value < 0:
+            raise ValueError(f"Number of retries must be >= 0 (got: {value})")
+        self._max_429_retries = value
+        self._reset_session()
+
+    @property
+    def max_total_retry_delay(self) -> float:
+        """
+        The maximum total time (in seconds) to spend waiting before giving up on
+        a request rejected with HTTP status 429. Default: 60.0
+
+        Set this to 0 to disable retrying of rate-limited requests. Since the
+        budget is checked after each wait, a request can take up to
+        ``max_total_retry_delay`` + ``max_retry_after`` seconds.
+        """
+        return self._max_total_retry_delay
+
+    @max_total_retry_delay.setter
+    def max_total_retry_delay(self, value: float) -> None:
+        if value < 0:
+            raise ValueError(f"Retry delay budget must be >= 0 (got: {value})")
+        self._max_total_retry_delay = value
+        self._reset_session()
+
+    @property
+    def max_retry_after(self) -> float:
+        """
+        The maximum time (in seconds) to wait before a single retry of a request
+        rejected with HTTP status 429. Default: 30.0
+
+        Longer delays requested by the server through the ``Retry-After`` header
+        are capped to this value.
+        """
+        return self._max_retry_after
+
+    @max_retry_after.setter
+    def max_retry_after(self, value: float) -> None:
+        if value < 0:
+            raise ValueError(f"Retry delay must be >= 0 (got: {value})")
+        self._max_retry_after = value
+        self._reset_session()
 
     @property
     def max_get_attempts(self) -> int:
@@ -143,7 +406,8 @@ class GalaxyClient:
         headers = self.json_headers
         kwargs.setdefault("timeout", self.timeout)
         kwargs.setdefault("verify", self.verify)
-        r = requests.get(url, headers=headers, **kwargs)
+        with self._session_ctx() as session:
+            r = session.get(url, headers=headers, **kwargs)
         return r
 
     def make_post_request(
@@ -184,15 +448,18 @@ class GalaxyClient:
             headers = self.json_headers
             post_params = params
 
-        r = requests.post(
-            url,
-            params=post_params,
-            data=data,
-            headers=headers,
-            timeout=self.timeout,
-            allow_redirects=False,
-            verify=self.verify,
-        )
+        # A multipart body is a stream which cannot be replayed, so such
+        # requests are not retried on HTTP status 429.
+        with self._session_ctx(retry=not files_attached) as session:
+            r = session.post(
+                url,
+                params=post_params,
+                data=data,
+                headers=headers,
+                timeout=self.timeout,
+                allow_redirects=False,
+                verify=self.verify,
+            )
         if r.status_code == 200:
             try:
                 return r.json()
@@ -224,15 +491,16 @@ class GalaxyClient:
         """
         data = json.dumps(payload) if payload is not None else None
         headers = self.json_headers
-        r = requests.delete(
-            url,
-            params=params,
-            data=data,
-            headers=headers,
-            timeout=self.timeout,
-            allow_redirects=False,
-            verify=self.verify,
-        )
+        with self._session_ctx() as session:
+            r = session.delete(
+                url,
+                params=params,
+                data=data,
+                headers=headers,
+                timeout=self.timeout,
+                allow_redirects=False,
+                verify=self.verify,
+            )
         return r
 
     def make_put_request(self, url: str, payload: dict | None = None, params: dict | None = None) -> Any:
@@ -246,15 +514,16 @@ class GalaxyClient:
         """
         data = json.dumps(payload) if payload is not None else None
         headers = self.json_headers
-        r = requests.put(
-            url,
-            params=params,
-            data=data,
-            headers=headers,
-            timeout=self.timeout,
-            allow_redirects=False,
-            verify=self.verify,
-        )
+        with self._session_ctx() as session:
+            r = session.put(
+                url,
+                params=params,
+                data=data,
+                headers=headers,
+                timeout=self.timeout,
+                allow_redirects=False,
+                verify=self.verify,
+            )
         if r.status_code == 200:
             try:
                 return r.json()
@@ -282,15 +551,16 @@ class GalaxyClient:
         """
         data = json.dumps(payload) if payload is not None else None
         headers = self.json_headers
-        r = requests.patch(
-            url,
-            params=params,
-            data=data,
-            headers=headers,
-            timeout=self.timeout,
-            allow_redirects=False,
-            verify=self.verify,
-        )
+        with self._session_ctx() as session:
+            r = session.patch(
+                url,
+                params=params,
+                data=data,
+                headers=headers,
+                timeout=self.timeout,
+                allow_redirects=False,
+                verify=self.verify,
+            )
         if r.status_code == 200:
             try:
                 return r.json()
@@ -366,12 +636,13 @@ class GalaxyClient:
             auth_url = f"{self.url}/authenticate/baseauth"
             # Use lower level method instead of make_get_request() because we
             # need the additional Authorization header.
-            r = requests.get(
-                auth_url,
-                headers=headers,
-                timeout=self.timeout,
-                verify=self.verify,
-            )
+            with self._session_ctx() as session:
+                r = session.get(
+                    auth_url,
+                    headers=headers,
+                    timeout=self.timeout,
+                    verify=self.verify,
+                )
             if r.status_code != 200:
                 raise Exception("Failed to authenticate user.")
             response = r.json()

--- a/bioblend/galaxyclient.py
+++ b/bioblend/galaxyclient.py
@@ -24,6 +24,7 @@ from requests.adapters import HTTPAdapter
 from requests_toolbelt import MultipartEncoder
 from tusclient.storage.filestorage import FileStorage
 from tusclient.uploader.uploader import Uploader
+from typing_extensions import Self
 from urllib3 import BaseHTTPResponse
 from urllib3.connectionpool import ConnectionPool
 from urllib3.util.retry import Retry
@@ -295,11 +296,11 @@ class GalaxyClient:
             self._session.close()
             self._session = None
 
-    def __enter__(self) -> "GalaxyClient":
+    def __enter__(self) -> Self:
         self.use_session = True
         return self
 
-    def __exit__(self, *args: Any) -> None:
+    def __exit__(self, *args: object) -> None:
         self.close()
 
     @property

--- a/docs/api_docs/lib_config.rst
+++ b/docs/api_docs/lib_config.rst
@@ -14,3 +14,14 @@ Config
 .. automodule:: bioblend.config
     :members:
     :undoc-members:
+
+Connection settings
+-------------------
+
+The following properties are available on both ``GalaxyInstance`` and
+``ToolShedInstance`` objects, and control how requests are retried and how
+connections are reused.
+
+.. autoclass:: bioblend.galaxyclient.GalaxyClient
+    :members: max_total_retry_delay, max_retry_after, max_429_retries,
+              use_session, close, max_get_attempts, get_retry_delay

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,57 @@ The developed scripts do not need to reside in any particular location on the sy
 It is probably best to take a look at the example scripts in ``docs/examples`` source
 directory and browse the `API documentation`_. Beyond that, it's up to your creativity :).
 
+Rate limiting
+=============
+
+Public Galaxy servers usually limit how many API requests a user may make in a
+given period of time, and reject the requests made over that limit with HTTP
+status 429 (Too Many Requests).
+
+BioBlend retries such requests automatically, so scripts do not need to handle
+them. When the server indicates through the ``Retry-After`` header how long to
+wait, that delay is honoured. Otherwise BioBlend waits for a progressively
+longer time between attempts. Every method is retried, including ``POST`` ones:
+a 429 response means that the request was rejected before being processed, so
+replaying it cannot duplicate anything on the server.
+
+Retrying is bounded, so that a rate-limited call fails in a predictable amount
+of time instead of blocking for as long as the server asks for. Once the total
+time spent waiting reaches ``max_total_retry_delay`` (60 seconds by default), a
+``bioblend.ConnectionError`` with a ``status_code`` of 429 is raised, just as if
+no retrying had taken place. The bounds can be changed on the Galaxy (or
+ToolShed) instance object::
+
+    from bioblend.galaxy import GalaxyInstance
+
+    gi = GalaxyInstance(url='https://usegalaxy.org', key='your_api_key')
+    # Give up after a total of 5 minutes of waiting.
+    gi.max_total_retry_delay = 300.0
+    # Never wait more than 1 minute before a single retry.
+    gi.max_retry_after = 60.0
+
+Setting ``max_total_retry_delay`` to 0 disables retrying altogether.
+
+Two kinds of requests are deliberately not retried: uploads sending a file as
+multipart form data, because their body is a stream which cannot be replayed,
+and requests which fail with a connection or read error, since those may have
+reached the server.
+
+Reusing connections
+===================
+
+By default, each request opens a new connection. Scripts making many requests
+can reuse a single session instead, which avoids re-establishing a connection
+every time::
+
+    with GalaxyInstance(url='https://usegalaxy.org', key='your_api_key') as gi:
+        for history in gi.histories.get_histories():
+            print(history['name'])
+
+Equivalently, ``gi.use_session = True`` enables it and ``gi.close()`` releases
+the connections. An instance with a session enabled should not be shared between
+threads.
+
 Development
 ===========
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ ToolShed) instance object::
 
     from bioblend.galaxy import GalaxyInstance
 
-    gi = GalaxyInstance(url='https://usegalaxy.org', key='your_api_key')
+    gi = GalaxyInstance(url="https://usegalaxy.org", key="your_api_key")
     # Give up after a total of 5 minutes of waiting.
     gi.max_total_retry_delay = 300.0
     # Never wait more than 1 minute before a single retry.
@@ -79,11 +79,13 @@ Reusing connections
 
 By default, each request opens a new connection. Scripts making many requests
 can reuse a single session instead, which avoids re-establishing a connection
-every time::
+every time. In the following example, one connection is used for the initial
+request and for the one made for each history returned by it::
 
-    with GalaxyInstance(url='https://usegalaxy.org', key='your_api_key') as gi:
+    with GalaxyInstance(url="https://usegalaxy.org", key="your_api_key") as gi:
         for history in gi.histories.get_histories():
-            print(history['name'])
+            datasets = gi.histories.show_history(history["id"], contents=True)
+            print(history["name"], len(datasets))
 
 Equivalently, ``gi.use_session = True`` enables it and ``gi.close()`` releases
 the connections. An instance with a session enabled should not be shared between

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "requests-toolbelt>=0.5.1,!=0.9.0",
     "tuspy",
     "typing-extensions",
+    # Required for the `backoff_max` and `backoff_jitter` retry settings
+    "urllib3>=2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Public Galaxy servers limit how many API requests a user may make in a given period of time, and reject the requests made over that limit with HTTP status 429 (Too Many Requests). BioBlend did not handle those in any way: the request simply failed with a `ConnectionError`.

Requests are now made through a `requests` session with a retrying adapter mounted, which honours the `Retry-After` header.

### What is retried

All methods, including `POST`: a 429 response means that the request was rejected before being processed, so replaying it cannot duplicate anything on the server.

Two kinds of requests are deliberately *not* retried:

* **Multipart uploads.** Neither urllib3 nor requests rewind the request body between attempts (requests only does it when resolving redirects), so a replayed multipart request would send a truncated body and then block waiting on its own `Content-Length`. `make_post_request(files_attached=True)` therefore uses a non-retrying session.
* **Connection and read errors**, which may have reached the server. Only the status counter of the retry policy is used, so these keep raising exactly the same exceptions as before.

### How retrying is bounded

By the total time spent waiting rather than by a number of attempts, so that a rate-limited call fails in a predictable amount of time instead of blocking for as long as the server asks for. urllib3 honours `Retry-After` but puts no upper bound on it, so both the individual waits and their total are capped:

| Property | Default | |
|---|---|---|
| `max_total_retry_delay` | 60.0 | total wait budget; 0 disables retrying |
| `max_retry_after` | 30.0 | cap on a single `Retry-After` |
| `max_429_retries` | 10 | backstop for when the waits are all zero |

Once the budget is spent, the usual `ConnectionError` is raised with the 429 status code and response body, so the existing contract is unchanged. Worst case is `max_total_retry_delay + max_retry_after`, as the budget is checked after each wait.

`Client._get()` no longer retries a 429 response, since it has already been retried while honouring `Retry-After`; trying again would only add load to an overloaded server. This only affects users who set `max_get_attempts` to a value greater than 1.

### Connection reuse

Since a session is created anyway, it can also be kept open to reuse connections across requests. This is opt-in through the new `use_session` property (plus `close()` and context manager support), because a shared session should not be used from multiple threads. By default a session is created and closed per request, which is exactly what `requests.get()` and friends did before, so there is no change for existing scripts.

### Tests

`bioblend/_tests/TestGalaxyRateLimit.py` adds 20 tests which do not need a Galaxy instance. They run against a minimal `http.server`-based server rather than using an HTTP mocking library, because the retrying happens inside urllib3, below the layer at which those libraries replace `HTTPAdapter.send` — mocking would silently bypass the whole feature.

### Note

Uploads through the tus endpoint (`get_tus_uploader()`) are not covered, as they are handled by `tusclient`, which has its own retry settings. Happy to wire that up too if wanted.
