### PR TITLE
Add Galaxy release_26.1 to the test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,10 @@ jobs:
             galaxy_python_version: '3.10'
           - os: ubuntu-latest
             tox_env: py310
+            galaxy_version: release_26.1
+            galaxy_python_version: '3.10'
+          - os: ubuntu-latest
+            tox_env: py310
             galaxy_version: release_26.0
             galaxy_python_version: '3.10'
           - os: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## BioBlend v1.10.0 - unreleased
 
+* Added support for Galaxy release 26.1.
+
 * Added ``UnprivilegedToolsClient`` with ``create_user_tool()``,
   ``get_user_tools()``, ``show_user_tool()``, and ``delete_user_tool()``
   methods for managing user-defined tools via the


### PR DESCRIPTION
Adds a CI job testing BioBlend against Galaxy `release_26.1` (Python 3.10, matching Galaxy's `requires-python = ">=3.10"` on that branch).