### PR TITLE
Fix rerun invocation input parameter ordering

### DIFF
--- a/bioblend/galaxy/invocations/__init__.py
+++ b/bioblend/galaxy/invocations/__init__.py
@@ -250,9 +250,7 @@ class InvocationClient(Client):
                 raise
             # Galaxy release_24.1 or earlier
             invocation = self.show_invocation(invocation_id)
-            workflow_step_id_to_index = {
-                step["workflow_step_id"]: index for index, step in enumerate(invocation["steps"])
-            }
+            workflow_step_id_to_index = {step["workflow_step_id"]: step["order_index"] for step in invocation["steps"]}
             # Merge input_step_parameters (indexed by label) into inputs (indexed by step index)
             inputs = invocation["inputs"]
             for param_input_dict in invocation["input_step_parameters"].values():


### PR DESCRIPTION
## Summary

Use each serialized invocation step's actual `order_index` when reconstructing parameter inputs for Galaxy 24.1 and earlier. The Galaxy 24.2+ invocation-request path, `inputs_update` handling, rerun endpoint, and existing functional tests remain unchanged.

## Root cause

The Galaxy 24.1-and-earlier fallback merged `input_step_parameters` into `inputs` by enumerating `invocation["steps"]`. That list comes from an unordered relationship, so its position is not a workflow order index. If the parameter-input step was serialized later in the list, BioBlend placed it under the wrong input key and Galaxy reported that the required `how_many` input was missing.

Affected Galaxy releases already serialize the workflow step's real `order_index` in `WorkflowInvocationStep.to_dict()`. This change maps `workflow_step_id` to that value directly, without relying on list order, encoded-ID order, or an additional API request.

This is independent of #542. The branch is based on BioBlend main SHA `b759fab1cc040e3e48690218e82e9221bd2254c0`, and its patch changes only `bioblend/galaxy/invocations/__init__.py`.

## CI evidence

The latent failure surfaced twice in #542's compatibility matrix run [32731672021](https://github.com/galaxyproject/bioblend/actions/runs/32731672021):

- [release_22.01 / Python 3.10 job 97445047602](https://github.com/galaxyproject/bioblend/actions/runs/32731672021/job/97445047602): 1 failed, 269 passed, 21 skipped
- [release_21.01 / Python 3.10 job 97445047701](https://github.com/galaxyproject/bioblend/actions/runs/32731672021/job/97445047701): 1 failed, 262 passed, 28 skipped

Both failed only `TestGalaxyInvocations.test_rerun_invocation_with_input_params` with Galaxy's HTTP 400 response saying required input step `how_many` had no input. The same Galaxy commits had passed against BioBlend main in scheduled run [32083093111](https://github.com/galaxyproject/bioblend/actions/runs/32083093111), consistent with nondeterministic relationship ordering.

## Verification

- `tox -e lint`: passed (ruff, flake8, Black, isort, mypy, ty)
- `git diff --check`: passed
- existing invocation test module collected unchanged; its 11 live-Galaxy tests skip locally without a configured server

I did not run the release_21.01 or release_22.01 integration tests locally; those remain for the compatibility-matrix CI on this PR.
